### PR TITLE
Update README for official Julia registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://astroshaper.github.io/AsteroidShapeModels.jl/dev/)
 [![Build Status](https://github.com/Astroshaper/AsteroidShapeModels.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/Astroshaper/AsteroidShapeModels.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/Astroshaper/AsteroidShapeModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/Astroshaper/AsteroidShapeModels.jl)
+[![PkgEval](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/A/AsteroidShapeModels.svg)](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/report.html)
 
 A Julia package for geometric processing of asteroid shape models.
 
@@ -22,9 +23,18 @@ A Julia package for geometric processing of asteroid shape models.
 
 ## Installation
 
+The package is registered in the [General Julia registry](https://github.com/JuliaRegistries/General) and can be installed with:
+
 ```julia
 using Pkg
-Pkg.add(url="https://github.com/Astroshaper/AsteroidShapeModels.jl")
+Pkg.add("AsteroidShapeModels")
+```
+
+Or from the Julia REPL:
+
+```julia
+julia> ]  # Press ] to enter package mode
+pkg> add AsteroidShapeModels
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Update README to reflect that the package is now registered in the official Julia General registry
- Add appropriate badges and installation instructions for registered packages

## Changes
- Add PkgEval badge to show package compatibility status
- Update installation instructions to use `Pkg.add("AsteroidShapeModels")` 
- Add Julia REPL package mode installation method (`] add AsteroidShapeModels`)
- Remove development version installation instructions (not needed for registered packages)

## Notes
The package has been successfully registered in the Julia General registry, so users can now install it directly without specifying the GitHub URL.

🤖 Generated with [Claude Code](https://claude.ai/code)