### PR TITLE
Fix CI badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://astroshaper.github.io/AsteroidShapeModels.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://astroshaper.github.io/AsteroidShapeModels.jl/dev/)
-[![Build Status](https://github.com/Astroshaper/AsteroidShapeModels.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/Astroshaper/AsteroidShapeModels.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Build Status](https://github.com/Astroshaper/AsteroidShapeModels.jl/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Astroshaper/AsteroidShapeModels.jl/actions/workflows/ci.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/Astroshaper/AsteroidShapeModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/Astroshaper/AsteroidShapeModels.jl)
 [![PkgEval](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/A/AsteroidShapeModels.svg)](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/report.html)
 


### PR DESCRIPTION
## Summary
Fix the Build Status badge that was not displaying correctly due to incorrect workflow filename casing.

## Changes
- Change `CI.yml` to `ci.yml` in the badge URL to match the actual workflow filename
- The workflow file is named with lowercase letters, but the badge URL was using uppercase

## Notes
This is a simple fix to ensure the CI status badge displays correctly in the README.

🤖 Generated with [Claude Code](https://claude.ai/code)