### PR TITLE
Add performance benchmarking infrastructure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ julia = "1.6"
 
 [extras]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 SPICE = "5bab7191-041a-5c2e-a744-024b9c3a5062"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -1,0 +1,255 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.5"
+manifest_format = "2.0"
+project_hash = "3e73647ce5051fe356a180566a884b071cef01bf"
+
+[[deps.AbstractTrees]]
+git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
+uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+version = "0.4.5"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BenchmarkTools]]
+deps = ["Compat", "JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "e38fbc49a620f5d0b660d7f543db1009fe0f8336"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "1.6.0"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.16.0"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.1.1+0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[deps.LeftChildRightSiblingTrees]]
+deps = ["AbstractTrees"]
+git-tree-sha1 = "fb6803dafae4a5d62ea5cab204b1e657d9737e7f"
+uuid = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
+version = "0.2.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.6.0+0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.7.2+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.11.0"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.6+0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.12.12"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.27+1"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.3"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.11.0"
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+    [deps.Pkg.weakdeps]
+    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.PkgBenchmark]]
+deps = ["BenchmarkTools", "Dates", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Pkg", "Printf", "TerminalLoggers", "UUIDs"]
+git-tree-sha1 = "dc06838e215d9c072fbdb9e9e5497d7f476ccaf5"
+uuid = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+version = "0.2.13"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.3"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Profile]]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+version = "1.11.0"
+
+[[deps.ProgressLogging]]
+deps = ["Logging", "SHA", "UUIDs"]
+git-tree-sha1 = "80d919dee55b9c50e8d9e2da5eeafff3fe58b539"
+uuid = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
+version = "0.1.4"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+    [deps.Statistics.weakdeps]
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.TerminalLoggers]]
+deps = ["LeftChildRightSiblingTrees", "Logging", "Markdown", "Printf", "ProgressLogging", "UUIDs"]
+git-tree-sha1 = "f133fab380933d042f6796eda4e130272ba520ca"
+uuid = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
+version = "0.1.7"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.11.0+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.59.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+AsteroidShapeModels = "a7943d8e-5d65-4248-ae23-0082f5115a05"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+AsteroidShapeModels = "0.2"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,54 @@
+# Performance Benchmarks for AsteroidShapeModels.jl
+
+This directory contains performance benchmarks for tracking the performance of `AsteroidShapeModels.jl` across different versions.
+
+## Running Benchmarks
+
+### Quick Run
+To run the benchmarks directly:
+```julia
+julia benchmark/benchmarks.jl
+```
+
+### Using PkgBenchmark
+For more detailed analysis and comparison between versions:
+
+```julia
+using PkgBenchmark
+using AsteroidShapeModels
+
+# Run benchmarks for current state
+results = benchmarkpkg(AsteroidShapeModels)
+
+# Compare against a specific version (e.g., v0.2.0)
+judge(AsteroidShapeModels, "v0.2.0")
+
+# Compare against a specific commit
+judge(AsteroidShapeModels, "main")
+```
+
+## Benchmark Categories
+
+1. **Loading**: Shape model loading with and without visibility calculations
+2. **Face Properties**: Face center, normal, and area calculations
+3. **Visibility**: Illumination checks and face visibility lookups
+4. **Ray Intersection**: Single triangle and full shape intersections
+5. **Bounding Box**: Computing and ray-box intersection
+6. **Shape Characteristics**: Volume, equivalent radius, max/min radius
+7. **Memory**: Memory allocation benchmarks
+
+## Interpreting Results
+
+- **Time**: Lower is better (measured in nanoseconds, microseconds, or milliseconds)
+- **Memory**: Lower allocation count and size is better
+- **Regression**: A significant increase in time or memory compared to baseline
+
+## Adding New Benchmarks
+
+To add new benchmarks, edit `benchmarks.jl` and add to the appropriate `SUITE` group:
+
+```julia
+SUITE["category"]["new_benchmark"] = @benchmarkable begin
+    # Your benchmark code here
+end
+```

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,113 @@
+using AsteroidShapeModels
+using BenchmarkTools
+using PkgBenchmark
+using StaticArrays
+
+# Load test shape model once
+const SHAPE_PATH = joinpath(@__DIR__, "..", "test", "shape", "ryugu_test.obj")
+const SHAPE     = load_shape_obj(SHAPE_PATH; find_visible_facets=false)
+const SHAPE_VIS = load_shape_obj(SHAPE_PATH; find_visible_facets=true)
+const BBOX = compute_bounding_box(SHAPE)
+
+# Benchmark suite
+const SUITE = BenchmarkGroup()
+
+# 1. Shape loading benchmarks
+SUITE["loading"] = BenchmarkGroup()
+SUITE["loading"]["without_visibility"] = @benchmarkable load_shape_obj($SHAPE_PATH; find_visible_facets=false)
+SUITE["loading"]["with_visibility"] = @benchmarkable load_shape_obj($SHAPE_PATH; find_visible_facets=true)
+
+# 2. Face property calculations
+SUITE["face_properties"] = BenchmarkGroup()
+let nodes = SHAPE.nodes, faces = SHAPE.faces
+    # Single face calculations
+    face = faces[1]
+    face_nodes = SA[nodes[face[1]], nodes[face[2]], nodes[face[3]]]
+    
+    SUITE["face_properties"]["face_center"] = @benchmarkable face_center($face_nodes)
+    SUITE["face_properties"]["face_normal"] = @benchmarkable face_normal($face_nodes)
+    SUITE["face_properties"]["face_area"]   = @benchmarkable face_area($face_nodes)
+    
+    # Batch calculations (100 faces)
+    SUITE["face_properties"]["batch_centers"] = @benchmarkable begin
+        for i in 1:100
+            face = $faces[i]
+            fn = SA[$nodes[face[1]], $nodes[face[2]], $nodes[face[3]]]
+            face_center(fn)
+        end
+    end
+end
+
+# 3. Visibility calculations
+SUITE["visibility"] = BenchmarkGroup()
+let view_dir = SA[1.0, 0.0, 0.0]
+    SUITE["visibility"]["single_face"] = @benchmarkable isilluminated($SHAPE_VIS, $view_dir, 1)
+    SUITE["visibility"]["batch_100_faces"] = @benchmarkable begin
+        for idx in 1:100
+            isilluminated($SHAPE_VIS, $view_dir, idx)
+        end
+    end
+    
+    # Visibility lookup
+    SUITE["visibility"]["visible_facets_lookup"] = @benchmarkable begin
+        vf = $SHAPE_VIS.visiblefacets[1]
+        length(vf)
+    end
+end
+
+# 4. Ray intersection benchmarks
+SUITE["ray_intersection"] = BenchmarkGroup()
+let ray = Ray([0.0, 0.0, 1000.0], [0.0, 0.0, -1.0])
+    # Single triangle intersection
+    face = SHAPE.faces[1]
+    A = SHAPE.nodes[face[1]]
+    B = SHAPE.nodes[face[2]]
+    C = SHAPE.nodes[face[3]]
+    
+    SUITE["ray_intersection"]["single_triangle"] = @benchmarkable intersect_ray_triangle($ray, $A, $B, $C)
+    
+    # Full shape intersection
+    SUITE["ray_intersection"]["full_shape"] = @benchmarkable intersect_ray_shape($ray, $SHAPE, $BBOX)
+    
+    # Multiple rays
+    rays = [Ray([x, y, 1000.0], [0.0, 0.0, -1.0]) for x in -500:100:500, y in -500:100:500]
+    SUITE["ray_intersection"]["multiple_rays"] = @benchmarkable begin
+        for ray in $rays
+            intersect_ray_shape(ray, $SHAPE, $BBOX)
+        end
+    end
+end
+
+# 5. Bounding box operations
+SUITE["bounding_box"] = BenchmarkGroup()
+SUITE["bounding_box"]["compute"] = @benchmarkable compute_bounding_box($SHAPE)
+let ray = Ray([0.0, 0.0, 1000.0], [0.0, 0.0, -1.0])
+    SUITE["bounding_box"]["intersection"] = @benchmarkable intersect_ray_bounding_box($ray, $BBOX)
+end
+
+# 6. Shape characteristics
+SUITE["shape_characteristics"] = BenchmarkGroup()
+SUITE["shape_characteristics"]["volume"] = @benchmarkable polyhedron_volume($SHAPE)
+SUITE["shape_characteristics"]["equivalent_radius"] = @benchmarkable equivalent_radius($SHAPE)
+SUITE["shape_characteristics"]["maximum_radius"] = @benchmarkable maximum_radius($SHAPE)
+SUITE["shape_characteristics"]["minimum_radius"] = @benchmarkable minimum_radius($SHAPE)
+
+# 7. Memory allocation benchmarks
+SUITE["memory"] = BenchmarkGroup()
+SUITE["memory"]["shape_model_creation"] = @benchmarkable begin
+    nodes = [SA[rand(), rand(), rand()] for _ in 1:1000]
+    faces = [SA[rand(1:1000), rand(1:1000), rand(1:1000)] for _ in 1:2000]
+    ShapeModel(nodes, faces; find_visible_facets=false)
+end
+
+# If running standalone (not through PkgBenchmark)
+if abspath(PROGRAM_FILE) == @__FILE__
+    results = run(SUITE, verbose=true)
+    println("\n=== Benchmark Results ===")
+    for (group_name, group) in results
+        println("\n$group_name:")
+        for (bench_name, bench) in group
+            println("  $bench_name: $(median(bench))")
+        end
+    end
+end


### PR DESCRIPTION
## Summary
Add comprehensive performance benchmarking infrastructure using PkgBenchmark.jl to track performance across versions.

## Motivation
Before implementing major structural changes in v0.3.0 (CSR format, nested models), we need baseline performance measurements to:
- Quantify the impact of changes
- Prevent performance regressions
- Make data-driven optimization decisions

## Changes
- Add `benchmark/benchmarks.jl` with comprehensive benchmark suite
- Add PkgBenchmark to test dependencies
- Create benchmark documentation in `benchmark/README.md`
- Configure benchmark environment in `benchmark/Project.toml`

## Benchmark Categories
1. **Loading**: Shape model loading with/without visibility
2. **Face Properties**: Centers, normals, areas calculations
3. **Visibility**: Illumination checks and face visibility lookups
4. **Ray Intersection**: Triangle and full shape intersections
5. **Bounding Box**: Computing and ray-box intersection
6. **Shape Characteristics**: Volume, radius calculations
7. **Memory**: Allocation benchmarks

## Usage
```julia
# Run benchmarks
julia benchmark/benchmarks.jl

# Or with PkgBenchmark for version comparison
using PkgBenchmark
results = benchmarkpkg(AsteroidShapeModels)
judge(AsteroidShapeModels, "v0.2.0")  # Compare against v0.2.0
```

## Notes
- The benchmarks will run automatically once v0.2.0 is available in the registry
- Currently uses registered v0.1.0; will update to v0.2.0 once available
- This establishes baseline measurements before v0.3.0 breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)