### PR TITLE
Make VisibleFace an internal type and unify terminology

### DIFF
--- a/src/AsteroidShapeModels.jl
+++ b/src/AsteroidShapeModels.jl
@@ -46,7 +46,7 @@ include("face_properties.jl")
 export face_center, face_normal, face_area
 
 include("types.jl")
-export VisibleFacet, Ray, BoundingBox
+export Ray, BoundingBox
 export RayTriangleIntersectionResult, RayShapeIntersectionResult
 
 include("face_visibility_graph.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,7 +3,7 @@
 
 Core type definitions for `AsteroidShapeModels.jl`.
 This file contains fundamental data structures used throughout the package:
-- `VisibleFacet`: Stores face-to-face visibility relationship data
+- `VisibleFacet`: Internal type for temporary visibility data storage
 - `Ray`: Represents a ray in 3D space for intersection tests
 - `BoundingBox`: Axis-aligned bounding box for acceleration structures
 - `RayTriangleIntersectionResult`: Result of ray-triangle intersection test
@@ -17,13 +17,17 @@ This file contains fundamental data structures used throughout the package:
 """
     struct VisibleFacet
 
-Index of an interfacing facet and its view factor
+Internal type for storing face-to-face visibility data during graph construction.
+This type is used temporarily in `build_face_visibility_graph!` before converting
+to the CSR format `FaceVisibilityGraph`.
 
 # Fields
 - `id` : Index of the interfacing facet
 - `f`  : View factor from facet i to j
 - `d`  : Distance from facet i to j
 - `d̂`  : Normal vector from facet i to j
+
+Note: This is an internal type and not exported.
 """
 struct VisibleFacet
     id::Int64

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,7 +3,7 @@
 
 Core type definitions for `AsteroidShapeModels.jl`.
 This file contains fundamental data structures used throughout the package:
-- `VisibleFacet`: Internal type for temporary visibility data storage
+- `VisibleFace`: Internal type for temporary visibility data storage
 - `Ray`: Represents a ray in 3D space for intersection tests
 - `BoundingBox`: Axis-aligned bounding box for acceleration structures
 - `RayTriangleIntersectionResult`: Result of ray-triangle intersection test
@@ -15,21 +15,21 @@ This file contains fundamental data structures used throughout the package:
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 """
-    struct VisibleFacet
+    struct VisibleFace
 
 Internal type for storing face-to-face visibility data during graph construction.
 This type is used temporarily in `build_face_visibility_graph!` before converting
 to the CSR format `FaceVisibilityGraph`.
 
 # Fields
-- `id` : Index of the interfacing facet
-- `f`  : View factor from facet i to j
-- `d`  : Distance from facet i to j
-- `d̂`  : Normal vector from facet i to j
+- `id` : Index of the interfacing face
+- `f`  : View factor from face i to j
+- `d`  : Distance from face i to j
+- `d̂`  : Normal vector from face i to j
 
 Note: This is an internal type and not exported.
 """
-struct VisibleFacet
+struct VisibleFace
     id::Int64
     f ::Float64
     d ::Float64

--- a/src/visibility.jl
+++ b/src/visibility.jl
@@ -97,7 +97,7 @@ function build_face_visibility_graph!(shape::ShapeModel)
     face_areas   = shape.face_areas
     
     # Accumulate temporary visible face data
-    temp_visible = [Vector{VisibleFacet}() for _ in faces]
+    temp_visible = [Vector{VisibleFace}() for _ in faces]
     
     for i in eachindex(faces)
         cᵢ = face_centers[i]
@@ -143,8 +143,8 @@ function build_face_visibility_graph!(shape::ShapeModel)
             end
 
             blocked && continue
-            push!(temp_visible[i], VisibleFacet(j, view_factor(cᵢ, cⱼ, n̂ᵢ, n̂ⱼ, aⱼ)...))
-            push!(temp_visible[j], VisibleFacet(i, view_factor(cⱼ, cᵢ, n̂ⱼ, n̂ᵢ, aᵢ)...))
+            push!(temp_visible[i], VisibleFace(j, view_factor(cᵢ, cⱼ, n̂ᵢ, n̂ⱼ, aⱼ)...))
+            push!(temp_visible[j], VisibleFace(i, view_factor(cⱼ, cᵢ, n̂ⱼ, n̂ᵢ, aᵢ)...))
         end
     end
     


### PR DESCRIPTION
## Summary
This PR makes `VisibleFace` (formerly `VisibleFacet`) an internal type and unifies terminology throughout the codebase to use "face" instead of "facet".

## Changes

### 1. Remove VisibleFacet/VisibleFace from exports
- The type is now internal and not exported
- Updated documentation to clarify it's an internal implementation detail
- Added note that it's used temporarily during visibility graph construction

### 2. Rename VisibleFacet to VisibleFace
- Changed struct name from `VisibleFacet` to `VisibleFace` for consistency
- Updated all references in `visibility.jl`
- Updated documentation to use "face" terminology

### 3. Documentation improvements
- Updated file-level documentation to reflect internal status
- Changed "interfacing facet" to "interfacing face" in docstrings
- Aligned with project-wide terminology

## Rationale
- `VisibleFace` is only used internally in `build_face_visibility_graph\!` as a temporary data structure
- Users interact with the `FaceVisibilityGraph` API, not with `VisibleFace` directly
- The project uses "face" terminology consistently (e.g., `face_centers`, `face_normals`, `build_face_visibility_graph\!`)
- Making it internal reduces the public API surface and allows for future optimization

## Impact
- **Breaking change**: `VisibleFacet` is no longer exported (but it was not meant for public use)
- No impact on normal usage patterns as users should use `FaceVisibilityGraph` methods
- Internal implementation detail that can be optimized in the future (e.g., when introducing ImplicitBVH.jl)

## Testing
All tests pass ✅ - the type works correctly as an internal implementation detail.