### PR TITLE
Rename `loadobj` to `load_obj` and remove message parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `get_visible_facet_data` → `get_visible_face_data`
   - `VisibleFacet` → `VisibleFace` (internal type, removed from exports)
 
+- **Function naming convention updates** (#18)
+  - `loadobj` → `load_obj` (follows Julia snake_case convention)
+  - Removed `message` parameter from `load_obj` function
+
 ### Changed
 - Removed redundant inner constructor from `ShapeModel`
 - Fixed face orientations in test shapes for correct visibility calculations
 - Used keyword argument shorthand syntax where applicable
+- Made `VisibleFacet` an internal type and renamed to `VisibleFace` (#17)
 
 ### Migration Guide
 
@@ -41,6 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Code Migration Examples
 
 ```julia
+# Loading OBJ files
+# Before (v0.2.x)
+nodes, faces = loadobj("path/to/shape.obj", message=false)
+# After (v0.3.0)
+nodes, faces = load_obj("path/to/shape.obj")
+# To get node/face counts:
+println("Loaded model with $(length(nodes)) nodes and $(length(faces)) faces.")
+
 # Loading shapes with visibility
 # Before (v0.2.x)
 shape = load_shape_obj("path/to/shape.obj"; find_visible_facets=true)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ nodes, faces = loadobj("path/to/shape.obj", message=false)
 # After (v0.3.0)
 nodes, faces = load_obj("path/to/shape.obj")
 # To get node/face counts:
-println("Loaded model with $(length(nodes)) nodes and $(length(faces)) faces.")
+println("Number of nodes: ", length(nodes))
+println("Number of faces: ", length(faces))
 
 # Loading shapes with visibility
 # Before (v0.2.x)

--- a/docs/src/api/io.md
+++ b/docs/src/api/io.md
@@ -8,7 +8,7 @@ CurrentModule = AsteroidShapeModels
 
 ```@docs
 load_shape_obj
-loadobj
+load_obj
 isobj
 ```
 

--- a/src/AsteroidShapeModels.jl
+++ b/src/AsteroidShapeModels.jl
@@ -13,7 +13,7 @@ visibility analysis, and surface roughness modeling.
 - `FaceVisibilityGraph`: CSR-style data structure for face-to-face visibility
 
 # Key Functions
-- Shape I/O: `load_shape_obj`, `loadobj`, `load_shape_grid`
+- Shape I/O: `load_shape_obj`, `load_obj`, `load_shape_grid`
 - Geometric properties: `face_center`, `face_normal`, `face_area`, `polyhedron_volume`
 - Ray intersection: `intersect_ray_triangle`, `intersect_ray_shape`
 - Visibility: `build_face_visibility_graph!`, `isilluminated`, `view_factor`
@@ -58,7 +58,7 @@ include("shape_model.jl")
 export ShapeModel
 
 include("obj_io.jl")
-export loadobj, isobj
+export load_obj, isobj
 
 include("ray_intersection.jl")
 export intersect_ray_triangle, intersect_ray_shape

--- a/src/obj_io.jl
+++ b/src/obj_io.jl
@@ -7,7 +7,7 @@ face connectivity information. This module handles the parsing and conversion of
 OBJ data into the internal representation used by AsteroidShapeModels.jl.
 
 Exported Functions:
-- `loadobj`: Load vertices and faces from an OBJ file
+- `load_obj`: Load vertices and faces from an OBJ file
 - `isobj`: Check if a file has the OBJ file extension
 =#
 
@@ -35,7 +35,7 @@ function isobj(filepath)
 end
 
 """
-    loadobj(shapepath::String; scale=1, message=true) -> nodes, faces
+    load_obj(shapepath::String; scale=1, message=true) -> nodes, faces
 
 Load a 3D shape model from an OBJ file.
 
@@ -53,20 +53,20 @@ Load a 3D shape model from an OBJ file.
 # Examples
 ```julia
 # Load shape model in meters
-nodes, faces = loadobj("asteroid.obj")
+nodes, faces = load_obj("asteroid.obj")
 
 # Load shape model and convert from km to m
-nodes, faces = loadobj("asteroid_km.obj", scale=1000)
+nodes, faces = load_obj("asteroid_km.obj", scale=1000)
 
 # Load without printing messages
-nodes, faces = loadobj("asteroid.obj", message=false)
+nodes, faces = load_obj("asteroid.obj", message=false)
 ```
 
 # Notes
 This function uses the FileIO/MeshIO packages to load OBJ files.
 Only triangular faces are supported.
 """
-function loadobj(shapepath::String; scale=1, message=true)
+function load_obj(shapepath::String; scale=1, message=true)
     mesh = load(shapepath)
     nodes = Vector{SVector{3, Float64}}(GeometryBasics.coordinates(mesh))
     faces = [SVector{3,Int}(convert.(Int, face)) for face in GeometryBasics.faces(mesh)]

--- a/src/obj_io.jl
+++ b/src/obj_io.jl
@@ -58,9 +58,8 @@ nodes, faces = load_obj("asteroid.obj")
 nodes, faces = load_obj("asteroid_km.obj", scale=1000)
 
 # Get the number of nodes and faces
-num_nodes = length(nodes)
-num_faces = length(faces)
-println("Loaded model with $num_nodes vertices and $num_faces faces.")
+println("Number of nodes: ", length(nodes))
+println("Number of faces: ", length(faces))
 
 # Access individual nodes and faces
 first_node = nodes[1]  # SVector{3, Float64}

--- a/src/obj_io.jl
+++ b/src/obj_io.jl
@@ -35,7 +35,7 @@ function isobj(filepath)
 end
 
 """
-    load_obj(shapepath::String; scale=1, message=true) -> nodes, faces
+    load_obj(shapepath::String; scale=1) -> nodes, faces
 
 Load a 3D shape model from an OBJ file.
 
@@ -44,7 +44,6 @@ Load a 3D shape model from an OBJ file.
 
 # Keyword Arguments
 - `scale::Real=1`: Scale factor to apply to all vertex coordinates. For example, use `scale=1000` to convert from kilometers to meters
-- `message::Bool=true`: Whether to print loading information
 
 # Returns
 - `nodes::Vector{SVector{3,Float64}}`: Array of vertex positions
@@ -58,28 +57,26 @@ nodes, faces = load_obj("asteroid.obj")
 # Load shape model and convert from km to m
 nodes, faces = load_obj("asteroid_km.obj", scale=1000)
 
-# Load without printing messages
-nodes, faces = load_obj("asteroid.obj", message=false)
+# Get the number of nodes and faces
+num_nodes = length(nodes)
+num_faces = length(faces)
+println("Loaded model with $num_nodes vertices and $num_faces faces.")
+
+# Access individual nodes and faces
+first_node = nodes[1]  # SVector{3, Float64}
+first_face = faces[1]  # SVector{3, Int} with node indices
 ```
 
 # Notes
 This function uses the FileIO/MeshIO packages to load OBJ files.
 Only triangular faces are supported.
 """
-function load_obj(shapepath::String; scale=1, message=true)
+function load_obj(shapepath::String; scale=1)
     mesh = load(shapepath)
     nodes = Vector{SVector{3, Float64}}(GeometryBasics.coordinates(mesh))
     faces = [SVector{3,Int}(convert.(Int, face)) for face in GeometryBasics.faces(mesh)]
 
     nodes *= scale  # if scale is 1000, converted [km] to [m]
-
-    if message == true
-        println("+-----------------------------+")
-        println("|        Load OBJ file        |")
-        println("+-----------------------------+")
-        println(" Nodes: ", length(nodes))
-        println(" Faces: ", length(faces))
-    end
 
     return nodes, faces
 end

--- a/src/shape_operations.jl
+++ b/src/shape_operations.jl
@@ -43,10 +43,10 @@ shape = load_shape_obj("asteroid.obj")
 shape = load_shape_obj("asteroid_km.obj", scale=1000, with_face_visibility=true)
 ```
 
-See also: [`load_shape_grid`](@ref), [`loadobj`](@ref)
+See also: [`load_shape_grid`](@ref), [`load_obj`](@ref)
 """
 function load_shape_obj(shapepath; scale=1.0, with_face_visibility=false)
-    nodes, faces = loadobj(shapepath; scale, message=false)
+    nodes, faces = load_obj(shapepath; scale, message=false)
     return ShapeModel(nodes, faces; with_face_visibility)
 end
 

--- a/src/shape_operations.jl
+++ b/src/shape_operations.jl
@@ -46,7 +46,7 @@ shape = load_shape_obj("asteroid_km.obj", scale=1000, with_face_visibility=true)
 See also: [`load_shape_grid`](@ref), [`load_obj`](@ref)
 """
 function load_shape_obj(shapepath; scale=1.0, with_face_visibility=false)
-    nodes, faces = load_obj(shapepath; scale, message=false)
+    nodes, faces = load_obj(shapepath; scale)
     return ShapeModel(nodes, faces; with_face_visibility)
 end
 

--- a/test/test_obj_io.jl
+++ b/test/test_obj_io.jl
@@ -41,8 +41,8 @@ This file verifies:
     @testset "OBJ Loading" begin
         @testset "Non-existent file" begin
             # Should throw an error when file doesn't exist
-            @test_throws Exception loadobj("nonexistent_file.obj")
-            @test_throws Exception loadobj("/path/to/nowhere/model.obj")
+            @test_throws Exception load_obj("nonexistent_file.obj")
+            @test_throws Exception load_obj("/path/to/nowhere/model.obj")
         end
         
         @testset "Scale parameter" begin
@@ -62,20 +62,20 @@ This file verifies:
             
             try
                 # Load with default scale
-                nodes1, faces1 = loadobj(temp_file, message=false)
+                nodes1, faces1 = load_obj(temp_file, message=false)
                 @test length(nodes1) == 3
                 @test length(faces1) == 1
                 @test nodes1[1] ≈ SA[1.0, 0.0, 0.0]
                 
                 # Load with scale = 2
-                nodes2, faces2 = loadobj(temp_file, scale=2.0, message=false)
+                nodes2, faces2 = load_obj(temp_file, scale=2.0, message=false)
                 @test length(nodes2) == 3
                 @test nodes2[1] ≈ SA[2.0, 0.0, 0.0]
                 @test nodes2[2] ≈ SA[0.0, 2.0, 0.0]
                 @test nodes2[3] ≈ SA[0.0, 0.0, 2.0]
                 
                 # Load with scale = 0.5
-                nodes3, faces3 = loadobj(temp_file, scale=0.5, message=false)
+                nodes3, faces3 = load_obj(temp_file, scale=0.5, message=false)
                 @test nodes3[1] ≈ SA[0.5, 0.0, 0.0]
                 
                 # Face indices should not change with scale
@@ -103,12 +103,12 @@ This file verifies:
             try
                 # Test that message=false doesn't print
                 # (Can't easily test stdout, but at least check it runs)
-                nodes, faces = loadobj(temp_file, message=false)
+                nodes, faces = load_obj(temp_file, message=false)
                 @test length(nodes) == 3
                 @test length(faces) == 1
                 
                 # Test that message=true works (default)
-                nodes, faces = loadobj(temp_file, message=true)
+                nodes, faces = load_obj(temp_file, message=true)
                 @test length(nodes) == 3
                 @test length(faces) == 1
             finally
@@ -134,7 +134,7 @@ This file verifies:
             end
             
             try
-                nodes, faces = loadobj(temp_file, message=false)
+                nodes, faces = load_obj(temp_file, message=false)
                 @test length(nodes) == 3
                 @test length(faces) == 1
             finally
@@ -158,7 +158,7 @@ This file verifies:
             end
             
             try
-                nodes, faces = loadobj(temp_file, message=false)
+                nodes, faces = load_obj(temp_file, message=false)
                 @test length(nodes) == 4
                 @test length(faces) == 2
                 @test faces[1] == SA[1, 2, 3]
@@ -188,7 +188,7 @@ This file verifies:
                 # Should throw an error or handle gracefully
                 # Redirect stderr to suppress FileIO error messages
                 redirect_stderr(devnull) do
-                    @test_throws Exception loadobj(temp_file, message=false)
+                    @test_throws Exception load_obj(temp_file, message=false)
                 end
             finally
                 rm(temp_file, force=true)
@@ -213,7 +213,7 @@ This file verifies:
                 # This should throw an error because vertex 4 doesn't exist
                 # Redirect stderr to suppress FileIO error messages
                 redirect_stderr(devnull) do
-                    @test_throws Exception loadobj(temp_file, message=false)
+                    @test_throws Exception load_obj(temp_file, message=false)
                 end
             finally
                 rm(temp_file, force=true)
@@ -227,7 +227,7 @@ This file verifies:
             end
             
             try
-                nodes, faces = loadobj(temp_file, message=false)
+                nodes, faces = load_obj(temp_file, message=false)
                 @test length(nodes) == 0
                 @test length(faces) == 0
             finally
@@ -247,7 +247,7 @@ This file verifies:
             if isfile(filepath)
                 @testset "Loading $obj_file" begin
                     # Test that file can be loaded
-                    nodes, faces = loadobj(filepath, message=false)
+                    nodes, faces = load_obj(filepath, message=false)
                     
                     # Basic sanity checks
                     @test length(nodes) > 0

--- a/test/test_obj_io.jl
+++ b/test/test_obj_io.jl
@@ -62,20 +62,20 @@ This file verifies:
             
             try
                 # Load with default scale
-                nodes1, faces1 = load_obj(temp_file, message=false)
+                nodes1, faces1 = load_obj(temp_file)
                 @test length(nodes1) == 3
                 @test length(faces1) == 1
                 @test nodes1[1] ≈ SA[1.0, 0.0, 0.0]
                 
                 # Load with scale = 2
-                nodes2, faces2 = load_obj(temp_file, scale=2.0, message=false)
+                nodes2, faces2 = load_obj(temp_file, scale=2.0)
                 @test length(nodes2) == 3
                 @test nodes2[1] ≈ SA[2.0, 0.0, 0.0]
                 @test nodes2[2] ≈ SA[0.0, 2.0, 0.0]
                 @test nodes2[3] ≈ SA[0.0, 0.0, 2.0]
                 
                 # Load with scale = 0.5
-                nodes3, faces3 = load_obj(temp_file, scale=0.5, message=false)
+                nodes3, faces3 = load_obj(temp_file, scale=0.5)
                 @test nodes3[1] ≈ SA[0.5, 0.0, 0.0]
                 
                 # Face indices should not change with scale
@@ -86,7 +86,7 @@ This file verifies:
             end
         end
         
-        @testset "Message suppression" begin
+        @testset "Basic loading" begin
             # Create a temporary test file
             test_obj_content = """
             v 1.0 0.0 0.0
@@ -101,14 +101,8 @@ This file verifies:
             end
             
             try
-                # Test that message=false doesn't print
-                # (Can't easily test stdout, but at least check it runs)
-                nodes, faces = load_obj(temp_file, message=false)
-                @test length(nodes) == 3
-                @test length(faces) == 1
-                
-                # Test that message=true works (default)
-                nodes, faces = load_obj(temp_file, message=true)
+                # Test basic loading
+                nodes, faces = load_obj(temp_file)
                 @test length(nodes) == 3
                 @test length(faces) == 1
             finally
@@ -134,7 +128,7 @@ This file verifies:
             end
             
             try
-                nodes, faces = load_obj(temp_file, message=false)
+                nodes, faces = load_obj(temp_file)
                 @test length(nodes) == 3
                 @test length(faces) == 1
             finally
@@ -158,7 +152,7 @@ This file verifies:
             end
             
             try
-                nodes, faces = load_obj(temp_file, message=false)
+                nodes, faces = load_obj(temp_file)
                 @test length(nodes) == 4
                 @test length(faces) == 2
                 @test faces[1] == SA[1, 2, 3]
@@ -188,7 +182,7 @@ This file verifies:
                 # Should throw an error or handle gracefully
                 # Redirect stderr to suppress FileIO error messages
                 redirect_stderr(devnull) do
-                    @test_throws Exception load_obj(temp_file, message=false)
+                    @test_throws Exception load_obj(temp_file)
                 end
             finally
                 rm(temp_file, force=true)
@@ -213,7 +207,7 @@ This file verifies:
                 # This should throw an error because vertex 4 doesn't exist
                 # Redirect stderr to suppress FileIO error messages
                 redirect_stderr(devnull) do
-                    @test_throws Exception load_obj(temp_file, message=false)
+                    @test_throws Exception load_obj(temp_file)
                 end
             finally
                 rm(temp_file, force=true)
@@ -227,7 +221,7 @@ This file verifies:
             end
             
             try
-                nodes, faces = load_obj(temp_file, message=false)
+                nodes, faces = load_obj(temp_file)
                 @test length(nodes) == 0
                 @test length(faces) == 0
             finally
@@ -247,7 +241,7 @@ This file verifies:
             if isfile(filepath)
                 @testset "Loading $obj_file" begin
                     # Test that file can be loaded
-                    nodes, faces = load_obj(filepath, message=false)
+                    nodes, faces = load_obj(filepath)
                     
                     # Basic sanity checks
                     @test length(nodes) > 0


### PR DESCRIPTION
## Summary

This PR renames the `loadobj` function to `load_obj` to follow Julia naming conventions and removes the `message` parameter that was used to print loading information.

## Changes

- **Function rename**: `loadobj` → `load_obj` throughout the codebase
- **Parameter removal**: Removed `message` parameter from `load_obj` function
- **Documentation**: 
  - Added usage examples showing how to access vertex/face counts
  - Updated API documentation
  - Updated CHANGELOG with migration guide
- **Tests**: Updated all test files to use the new function name

## Migration Guide

If you were using the `message` parameter:

```julia
# Old (v0.2.x)
nodes, faces = loadobj("model.obj", message=false)

# New (v0.3.0)
nodes, faces = load_obj("model.obj")

# To get node/face counts, use:
println("Number of nodes: ", length(nodes))
println("Number of faces: ", length(faces))
```

## Breaking Changes

1. Function renamed from `loadobj` to `load_obj`
2. `message` parameter removed - users should manually print counts if needed

This change is targeted for v0.3.0 release.