### PR TITLE
Fix stable documentation build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - dev
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,4 +30,6 @@ makedocs(;
 deploydocs(;
     repo="github.com/Astroshaper/AsteroidShapeModels.jl",
     devbranch="main",
+    push_preview=true,
+    versions=["stable" => "v^", "v#.#", "dev" => "dev"],
 )


### PR DESCRIPTION
## Summary

This PR fixes the 404 error for stable documentation by configuring the CI workflow and Documenter to properly build versioned documentation.

## Changes

1. **CI Workflow Update**:
   - Added tag trigger (`v*`) to the CI workflow
   - This ensures documentation is built when new version tags are pushed

2. **Documenter Configuration**:
   - Added `push_preview=true` for PR preview builds
   - Added explicit version configuration:
     - `"stable"` maps to the latest tagged version
     - `"v#.#"` creates version-specific documentation
     - `"dev"` remains for the main branch

## Expected Behavior

After merging this PR:
1. Future tagged releases will automatically build stable documentation
2. The stable documentation URL will work correctly
3. Version selector will show all available versions

## Next Steps

After merging, we may need to manually trigger a documentation build for the existing v0.3.0 tag to populate the stable documentation.