### PR TITLE
Drop Julia 1.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
           - '1.10'
           - '1'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ GeometryBasics = "0.5"
 LinearAlgebra = "1"
 MeshIO = "0.5"
 StaticArrays = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ For detailed documentation, please visit:
 - **Visibility Analysis**: Calculate visibility and view factors between faces
 - **Shape Characteristics**: Calculate volume, equivalent radius, maximum and minimum radii
 
+## Requirements
+
+- Julia 1.10 or later
+
 ## Installation
 
 The package is registered in the [General Julia registry](https://github.com/JuliaRegistries/General) and can be installed with:


### PR DESCRIPTION
## Summary
- Drop support for Julia 1.6, updating minimum version to Julia 1.10
- This change is required for upcoming features that depend on packages requiring Julia 1.10+

## Changes
- Update `Project.toml` to require Julia 1.10
- Remove Julia 1.6 from CI test matrix
- Add Julia version requirement to README

## Breaking Change
This is a breaking change that increases the minimum Julia version from 1.6 to 1.10.

## Motivation
Several dependencies and upcoming features require Julia 1.10 or later. Julia 1.10 is the current LTS release, making this a reasonable minimum version requirement.

🤖 Generated with [Claude Code](https://claude.ai/code)