### PR TITLE
Unify ray intersection to BVH implementation only

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,8 @@ Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SPICE = "5bab7191-041a-5c2e-a744-024b9c3a5062"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SPICE", "Downloads", "Random", "BenchmarkTools"]
+test = ["Test", "SPICE", "Downloads", "Random", "BenchmarkTools", "Statistics"]

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -83,7 +83,7 @@ direction = normalize(SA[-1.0, 0.0, 0.0])  # Point toward origin
 ray = Ray(origin, direction)
 
 # Find intersection with shape
-result = intersect_ray_shape(ray, shape, bbox)
+result = intersect_ray_shape(ray, shape)
 
 if result.hit
     println("Ray hit face $(result.face_index) at distance $(result.distance).")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ using LinearAlgebra
 using Random
 using SPICE
 using StaticArrays
+using Statistics
 using Test
 
 # Include test helper functions

--- a/test/test_bvh_comprehensive.jl
+++ b/test/test_bvh_comprehensive.jl
@@ -29,7 +29,7 @@ All tests include correctness verification and performance benchmarks.
     
     # Load shape models
     println("\nLoading shape models...")
-    shape_no_bvh = load_shape_obj(shape_filepath; with_bvh=false, with_face_visibility=false)
+    shape_no_bvh   = load_shape_obj(shape_filepath; with_bvh=false, with_face_visibility=false)
     shape_with_bvh = load_shape_obj(shape_filepath; with_bvh=true, with_face_visibility=false)
     
     n_nodes = length(shape_no_bvh.nodes)
@@ -41,7 +41,7 @@ All tests include correctness verification and performance benchmarks.
     println("  - BVH built: $(!isnothing(shape_with_bvh.bvh))")
     
     # ═══════════════════════════════════════════════════════════════════
-    # Part 1: Ray-Shape Intersection with BVH
+    #   Part 1: Ray-Shape Intersection with BVH
     # ═══════════════════════════════════════════════════════════════════
     
     @testset "Ray-Shape Intersection BVH" begin
@@ -50,7 +50,6 @@ All tests include correctness verification and performance benchmarks.
         println("="^70)
         
         # Generate test rays
-        bbox = compute_bounding_box(shape_no_bvh)
         Random.seed!(42)
         n_test_rays = 50
         rays = []
@@ -69,8 +68,8 @@ All tests include correctness verification and performance benchmarks.
         
         mismatches = 0
         for (i, ray) in enumerate(rays)
-            result_no_bvh = intersect_ray_shape(ray, shape_no_bvh, bbox)
-            result_with_bvh = intersect_ray_shape(ray, shape_with_bvh, bbox)
+            result_no_bvh   = intersect_ray_shape(ray, shape_no_bvh)
+            result_with_bvh = intersect_ray_shape(ray, shape_with_bvh)
             
             if result_no_bvh.hit != result_with_bvh.hit
                 mismatches += 1
@@ -96,21 +95,21 @@ All tests include correctness verification and performance benchmarks.
         
         test_ray = rays[1]
         
-        time_no_bvh = @belapsed intersect_ray_shape($test_ray, $shape_no_bvh, $bbox)
+        time_no_bvh = @belapsed intersect_ray_shape($test_ray, $shape_no_bvh)
         println("  Single ray - Without BVH : $(round(time_no_bvh * 1e6, digits=2)) μs")
         
-        time_with_bvh = @belapsed intersect_ray_shape($test_ray, $shape_with_bvh, $bbox)
+        time_with_bvh = @belapsed intersect_ray_shape($test_ray, $shape_with_bvh)
         println("  Single ray - With BVH    : $(round(time_with_bvh * 1e6, digits=2)) μs")
         println("  Single ray - Speedup     : $(round(time_no_bvh / time_with_bvh, digits=2))x")
         
         # Batch rays
         time_batch_no_bvh = @belapsed for ray in $rays
-            intersect_ray_shape(ray, $shape_no_bvh, $bbox)
+            intersect_ray_shape(ray, $shape_no_bvh)
         end
         println("\n  Batch ($n_test_rays rays) - Without BVH: $(round(time_batch_no_bvh * 1000, digits=2)) ms")
         
         time_batch_with_bvh = @belapsed for ray in $rays
-            intersect_ray_shape(ray, $shape_with_bvh, $bbox)
+            intersect_ray_shape(ray, $shape_with_bvh)
         end
         println("  Batch ($n_test_rays rays) - With BVH: $(round(time_batch_with_bvh * 1000, digits=2)) ms")
         println("  Batch - Speedup: $(round(time_batch_no_bvh / time_batch_with_bvh, digits=2))x")
@@ -118,8 +117,8 @@ All tests include correctness verification and performance benchmarks.
         @test time_batch_with_bvh < time_batch_no_bvh
         
         # Hit rate
-        hits_no_bvh = sum(ray -> intersect_ray_shape(ray, shape_no_bvh, bbox).hit, rays)
-        hits_with_bvh = sum(ray -> intersect_ray_shape(ray, shape_with_bvh, bbox).hit, rays)
+        hits_no_bvh   = sum(ray -> intersect_ray_shape(ray, shape_no_bvh).hit, rays)
+        hits_with_bvh = sum(ray -> intersect_ray_shape(ray, shape_with_bvh).hit, rays)
         
         println("\n  Hit rate:")
         println("    Without BVH : $hits_no_bvh / $n_test_rays")
@@ -129,7 +128,7 @@ All tests include correctness verification and performance benchmarks.
     end
     
     # ═══════════════════════════════════════════════════════════════════
-    # Part 2: isilluminated Function with BVH
+    #   Part 2: isilluminated Function with BVH
     # ═══════════════════════════════════════════════════════════════════
     
     @testset "isilluminated BVH" begin
@@ -198,7 +197,7 @@ All tests include correctness verification and performance benchmarks.
     end
     
     # ═══════════════════════════════════════════════════════════════════
-    # Part 3: build_face_visibility_graph! with BVH
+    #   Part 3: build_face_visibility_graph! with BVH
     # ═══════════════════════════════════════════════════════════════════
     
     @testset "build_face_visibility_graph! BVH" begin

--- a/test/test_ray_intersection.jl
+++ b/test/test_ray_intersection.jl
@@ -141,16 +141,13 @@ This file verifies:
         v1, v2, v3 = nodes[1], nodes[2], nodes[3]
         
         # Create shape model
-        shape = ShapeModel(nodes, faces)
+        shape = ShapeModel(nodes, faces; with_bvh=true)
         
         # Test ray intersection with the shape
         ray = Ray(@SVector([0.25, 0.25, 1.0]), @SVector([0.0, 0.0, -1.0]))
         
-        # Compute bounding box for acceleration
-        bbox = compute_bounding_box(shape)
-        
         # Test intersection
-        result = intersect_ray_shape(ray, shape, bbox)
+        result = intersect_ray_shape(ray, shape)
         
         # Verify results
         test_ray_intersection(result, true, 1.0, @SVector([0.25, 0.25, 0.0]))

--- a/test/test_ray_intersection.jl
+++ b/test/test_ray_intersection.jl
@@ -153,4 +153,26 @@ This file verifies:
         test_ray_intersection(result, true, 1.0, @SVector([0.25, 0.25, 0.0]))
         @test result.face_index == 1  # Hit the first (and only) face
     end
+    
+    @testset "BVH Auto-build Test" begin
+        # Test that BVH is automatically built when needed
+        
+        # Create shape model WITHOUT BVH
+        nodes, faces = create_xy_triangle()
+        shape_no_bvh = ShapeModel(nodes, faces; with_bvh=false)
+        
+        # Verify BVH is not built initially
+        @test isnothing(shape_no_bvh.bvh)
+        
+        # Perform ray intersection - this should trigger BVH build
+        ray = Ray(@SVector([0.25, 0.25, 1.0]), @SVector([0.0, 0.0, -1.0]))
+        result = intersect_ray_shape(ray, shape_no_bvh)
+        
+        # Verify BVH was built automatically
+        @test !isnothing(shape_no_bvh.bvh)
+        
+        # Verify intersection result is correct
+        test_ray_intersection(result, true, 1.0, @SVector([0.25, 0.25, 0.0]))
+        @test result.face_index == 1
+    end
 end

--- a/test/test_ray_intersection_vs_spice.jl
+++ b/test/test_ray_intersection_vs_spice.jl
@@ -90,7 +90,7 @@ compared to the industry-standard SPICE toolkit.
     # Load the Didymos shape model and prepare for ray intersection
 
     obj_path = joinpath("shape", "g_01165mm_spc_obj_didy_0000n00000_v003.obj")
-    shape = load_shape_obj(obj_path; scale=1000.0)  # Convert km to m
+    shape = load_shape_obj(obj_path; scale=1000.0, with_bvh=true)  # Convert km to m
     println(shape)
 
     # ================================================================

--- a/test/test_ray_intersection_vs_spice.jl
+++ b/test/test_ray_intersection_vs_spice.jl
@@ -125,11 +125,8 @@ compared to the industry-standard SPICE toolkit.
     # Create ray for intersection test
     ray = Ray(camera_position, camera_boresight)
         
-    # Compute bounding box for acceleration
-    bbox = compute_bounding_box(shape)
-        
     # Perform ray intersection with our implementation
-    intersection = intersect_ray_shape(ray, shape, bbox)
+    intersection = intersect_ray_shape(ray, shape)
 
     # ================================================================
     #                  SPICE sincpt Comparison
@@ -177,7 +174,7 @@ compared to the industry-standard SPICE toolkit.
     # Compare computation times between implementations
     println("Computation time")
     print("    ∘ intersect_ray_shape in AsteroidShapeModels.jl :")
-    @time intersect_ray_shape(ray, shape, bbox)
+    @time intersect_ray_shape(ray, shape)
     print("    ∘ sincpt in SPICE.jl                            :")
     @time SPICE.sincpt("DSK/UNPRIORITIZED", obs, et, ref, abcorr, "HERA_TIRI", "HERA_TIRI", collect(boresight))
 

--- a/test/test_ryugu_shape_model.jl
+++ b/test/test_ryugu_shape_model.jl
@@ -56,8 +56,7 @@ This file benchmarks performance with a realistic asteroid shape model:
     # 4. Benchmark ray intersection
     println("\n4. Benchmarking ray-shape intersection:")
     ray = Ray([0.0, 0.0, 1000.0], [0.0, 0.0, -1.0])
-    bbox = compute_bounding_box(shape)
-    bench_ray = @benchmark intersect_ray_shape($ray, $shape, $bbox)
+    bench_ray = @benchmark intersect_ray_shape($ray, $shape)
     display(bench_ray)
     println()
         


### PR DESCRIPTION
## Summary
- Unified `intersect_ray_shape` function to use BVH implementation only
- Removed internal `_intersect_ray_shape_linear` and `_intersect_ray_shape_bvh` functions
- Removed `bbox` parameter from function signature (breaking change)
- Updated all tests and documentation to reflect the new API

## Breaking Changes
The `intersect_ray_shape` function signature has changed from:
```julia
intersect_ray_shape(ray::Ray, shape::ShapeModel, bbox::BoundingBox)
```
to:
```julia
intersect_ray_shape(ray::Ray, shape::ShapeModel)
```

## Implementation Details of `intersect_ray_shape`
- BVH is now built automatically when needed (if not already built)
- Removed redundant bounding box checks
- Simplified the implementation by removing the dual-path logic

## Test Updates
- Updated all test files to remove `bbox` parameter usage
- Modified `test_bvh_comprehensive.jl` to test BVH implementation only for ray intersection
- Added Statistics package to test dependencies
- All tests pass successfully

## Related to
- Part of v0.4.0 development plan
- Implements task 1 from the roadmap: "Unify ray intersection to BVH implementation only"

🤖 Generated with [Claude Code](https://claude.ai/code)