### PR TITLE
Add batch ray processing capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Batch ray processing functionality**
+  - Multiple dispatch for `intersect_ray_shape` to handle various input formats:
+    - `intersect_ray_shape(rays::Vector{Ray}, shape)` for ray collections
+    - `intersect_ray_shape(rays::Matrix{Ray}, shape)` preserves grid structure.
+    - `intersect_ray_shape(shape, origins, directions)` matching `ImplicitBVH`
+  - Efficient batch processing using single BVH traversal
+  - Results maintain input shape for vector/matrix inputs
+
+### Documentation
+- Enhanced `intersect_ray_triangle` docstrings with backface culling behavior details
+- Added batch ray processing examples to tutorial
+- Updated performance tips with batch operation recommendations
+
 ## [0.3.1] - 2025-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For future development plans, see our [Development Roadmap](ROADMAP.md).
 - **Shape Model Loading**: Load 3D models in OBJ file format
 - **Face Geometric Properties**: Calculate face centers, normal vectors, and areas
 - **Ray Intersection Detection**: High-precision ray-triangle intersection using the Möller–Trumbore algorithm with BVH (Bounding Volume Hierarchy) acceleration for efficient computation
+  - **Batch Ray Processing**: Process multiple rays efficiently in vectors or matrices while preserving input structure
 - **Visibility Analysis**: Calculate visibility and view factors between faces
   - **NEW**: BVH-accelerated visibility calculations (The current BVH implementation is slower than traditional implementations and has room for optimization.)
 - **Shape Characteristics**: Calculate volume, equivalent radius, maximum and minimum radii
@@ -51,12 +52,21 @@ pkg> add AsteroidShapeModels
 
 ```julia
 using AsteroidShapeModels
+using StaticArrays
 
 # Load an asteroid shape model with face-face visibility
 shape = load_shape_obj("path/to/shape.obj"; scale=1000, with_face_visibility=true)  # Convert km to m
 
 # Ray intersection automatically uses BVH acceleration when needed
 # (BVH is built on first use if not already present)
+
+# Single ray intersection
+ray = Ray(SA[1000.0, 0.0, 0.0], SA[-1.0, 0.0, 0.0])
+result = intersect_ray_shape(ray, shape)
+
+# Batch ray processing (NEW)
+rays = [Ray(SA[x, 0.0, 1000.0], SA[0.0, 0.0, -1.0]) for x in -500:100:500]
+results = intersect_ray_shape(rays, shape)
 
 # Access to face properties
 shape.face_centers  # Center position of each face

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,10 +7,10 @@ This document outlines the development plans and milestones for `AsteroidShapeMo
 ### Major Changes (Breaking Changes)
 - **Full Integration of `ImplicitBVH.jl`**
   - [x] Add performance benchmarks
-  - [x] Unify ray intersection to BVH implementation only
-    - [x] Remove legacy non-BVH implementation
-    - [x] Remove custom `BoundingBox` type in favor of `ImplicitBVH`'s BBox
-    - [ ] Add batch ray processing capability
+  - [x] Unify ray intersection to BVH implementation only (#28)
+    - [x] Remove legacy non-BVH implementation (#28)
+    - [x] Remove custom `BoundingBox` type in favor of `ImplicitBVH`'s BBox (#28)
+    - [x] Add batch ray processing capability (#29)
   - [ ] Unify face visibility graph to non-BVH implementation (cf. `build_face_visibility_graph` function)
   - [ ] Unify illumination check to non-BVH implementation (cf. `isilluminated` function)
   

--- a/src/ray_intersection.jl
+++ b/src/ray_intersection.jl
@@ -16,7 +16,6 @@ Exported Functions:
 - `intersect_ray_shape`: Find ray-shape intersections (single ray or batch processing)
 =#
 
-
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║               Ray-Triangle Intersection (Möller-Trumbore)         ║
 # ╚═══════════════════════════════════════════════════════════════════╝

--- a/src/ray_intersection.jl
+++ b/src/ray_intersection.jl
@@ -212,7 +212,7 @@ ray = Ray(SA[0.0, 0.0, 1000.0], SA[0.0, 0.0, -1.0])
 result = intersect_ray_shape(ray, shape)
 
 if result.hit
-    println("Hit face $(result.face_index) at distance $(result.distance)")
+    println("Hit face \$(result.face_index) at distance \$(result.distance)")
 end
 ```
 """
@@ -248,7 +248,7 @@ results = intersect_ray_shape(rays, shape)
 
 # Count hits
 n_hits = count(r -> r.hit, results)
-println("$n_hits out of $(length(rays)) rays hit the shape")
+println("\$n_hits out of \$(length(rays)) rays hit the shape")
 ```
 """
 function intersect_ray_shape(rays::AbstractVector{Ray}, shape::ShapeModel)::Vector{RayShapeIntersectionResult}
@@ -289,7 +289,7 @@ results = intersect_ray_shape(rays, shape)
 # Process results while preserving grid structure
 for i in 1:size(results, 1), j in 1:size(results, 2)
     if results[i, j].hit
-        println("Ray at ($i, $j) hit at $(results[i, j].point)")
+        println("Ray at (\$i, \$j) hit at \$(results[i, j].point)")
     end
 end
 ```

--- a/src/ray_intersection.jl
+++ b/src/ray_intersection.jl
@@ -2,15 +2,18 @@
     ray_intersection.jl
 
 This file implements ray-shape intersection algorithms for asteroid shape models.
-It includes the Möller-Trumbore algorithm for ray-triangle intersection,
-bounding box calculations for acceleration, and functions for testing
-intersections between rays and complete shape models.
+It includes the Möller-Trumbore algorithm for ray-triangle intersection with
+BVH (Bounding Volume Hierarchy) acceleration for efficient computation.
+
+Key Features:
+- Ray-triangle intersection using the Möller-Trumbore algorithm
+- BVH-accelerated ray-shape intersection (via `ImplicitBVH.jl`)
+- Batch ray processing for vectors and matrices of rays
+- No backface culling (triangles are hit from both sides)
 
 Exported Functions:
-- `compute_bounding_box`: Compute the axis-aligned bounding box of a shape
-- `intersect_ray_bounding_box`: Test ray-bounding box intersection
 - `intersect_ray_triangle`: Test ray-triangle intersection using Möller-Trumbore algorithm
-- `intersect_ray_shape`: Find the closest intersection between a ray and a shape model
+- `intersect_ray_shape`: Find ray-shape intersections (single ray or batch processing)
 =#
 
 


### PR DESCRIPTION
## Summary
This PR adds batch ray processing functionality to significantly improve performance when processing multiple rays. The implementation uses multiple dispatch to support various input formats while maintaining backward compatibility.

## Key Changes
- Add batch processing variants of `intersect_ray_shape`:
  - `intersect_ray_shape(rays::Vector{Ray}, shape)` for ray collections
  - `intersect_ray_shape(rays::Matrix{Ray}, shape)` preserves grid structure
  - `intersect_ray_shape(shape, origins, directions)` matching `ImplicitBVH.traverse_rays` interface
- Optimize single ray path to reduce memory allocations

## Performance Improvements
Benchmarks on test shape (121 rays in 11×11 grid):
- Loop processing: 42.1 μs (baseline)
- Batch vector: 6.3 μs (**6.6x faster**)
- Batch matrix: 6.4 μs (**6.6x faster**)  
- Raw matrix interface: 5.4 μs (**7.8x faster**)

Memory allocations reduced significantly with batch processing.

## Documentation Updates
- Enhanced `intersect_ray_triangle` docstrings with backface culling behavior details
- Added batch ray processing examples to tutorial
- Updated `README.md` with batch processing features
- Added `CHANGELOG.md` entry
- Updated `ROADMAP.md` to mark task as completed

## Test Coverage
- Comprehensive tests for all batch processing variants
- Edge case handling (empty arrays, single element arrays)
- Verification that matrix results preserve input shape

## Related Issues
Part of v0.4.0 roadmap - BVH Integration and Optimization

🤖 Generated with [Claude Code](https://claude.ai/code)