### PR TITLE
docs: Add BVH requirement to apply_eclipse_shadowing\! function

### DIFF
--- a/src/visibility.jl
+++ b/src/visibility.jl
@@ -540,6 +540,7 @@ function apply_eclipse_shadowing!(
     R₁₂::StaticMatrix{3,3}, t₁₂::StaticVector{3}, shape2::ShapeModel
 )::EclipseStatus
     @assert length(illuminated) == length(shape1.faces) "illuminated vector must have same length as number of faces."
+    isnothing(shape2.bvh) && throw(ArgumentError("Occluding shape model (`shape2`) must have BVH built before checking eclipse shadowing. Call `build_bvh!(shape2)` first."))
     
     r̂☉₁ = normalize(r☉₁)        # Normalized sun direction in shape1's frame
     r̂☉₂ = normalize(R₁₂ * r̂☉₁)  # Normalized sun direction in shape2's frame

--- a/src/visibility.jl
+++ b/src/visibility.jl
@@ -463,12 +463,15 @@ Apply eclipse shadowing effects from another shape onto already illuminated face
 - `r☉₁`         : Sun's position in shape1's frame
 - `R₁₂`         : 3×3 rotation matrix from `shape1` frame to `shape2` frame
 - `t₁₂`         : 3D translation vector from `shape1` frame to `shape2` frame
-- `shape2`      : Occluding shape model that may cast shadows on `shape1`
+- `shape2`      : Occluding shape model that may cast shadows on `shape1` (must have BVH built via `build_bvh!`)
 
 # Returns
 - `NO_ECLIPSE`: No eclipse occurs (bodies are misaligned).
 - `PARTIAL_ECLIPSE`: Some faces that were illuminated are now in shadow by the occluding body.
 - `TOTAL_ECLIPSE`: All faces that were illuminated are now in shadow.
+
+# Throws
+- `ArgumentError` if `shape2` does not have BVH built. Call `build_bvh!(shape2)` before using this function.
 
 # Description
 This function ONLY checks for mutual shadowing (eclipse) effects. It assumes that


### PR DESCRIPTION
## Summary

This PR adds BVH requirement documentation and validation to the `apply_eclipse_shadowing\!` function, which internally uses `intersect_ray_shape`.

## Changes

1. **Documentation update** (c6dd2e0)
   - Added BVH requirement for `shape2` parameter in docstring
   - Added `ArgumentError` documentation in the Throws section
   - Clarified that `shape2` must have BVH built before use

2. **Runtime validation** (ccbf1a1)
   - Added `isnothing(shape2.bvh)` check at the beginning of the function
   - Throws `ArgumentError` with clear error message if BVH is not built
   - Ensures early error detection before any computation

## Related to

This completes the BVH mandatory changes started in commits 04d2937 and 5355dbc (already in main).

## Testing

The existing tests already ensure `shape2` has BVH built when loading:
```julia
shape2 = load_shape_obj("secondary_shape.obj"; scale=1000, with_face_visibility=true, with_bvh=true)
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>