### PR TITLE
refactor!: Standardize face index variable names to `face_idx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - More consistent with other functions like `intersect_ray_triangle`
   - Update your code: `get_face_nodes(nodes, faces[i])` → `get_face_nodes(nodes, faces, i)`
 
+- **Standardized face index naming to `face_idx`** (pending PR)
+  - All face index parameters renamed from `face_id` or `i` to `face_idx`
+  - `RayShapeIntersectionResult.face_index` field renamed to `face_idx`
+  - Update your code: `result.face_index` → `result.face_idx`
+  - This change improves consistency across the entire API
+
 ### Added
 - **Batch ray processing functionality** (#29)
   - Multiple dispatch for `intersect_ray_shape` to handle various input formats:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Standardized face index naming to `face_idx`** (pending PR)
   - All face index parameters renamed from `face_id` or `i` to `face_idx`
   - `RayShapeIntersectionResult.face_index` field renamed to `face_idx`
-  - `VisibleFace.id` field renamed to `face_idx`
+  - `VisibleFace` struct fields renamed for clarity:
+    - `id` → `face_idx`
+    - `f` → `view_factor`
+    - `d` → `distance`
+    - `d̂` → `direction`
+  - `get_visible_face_data` return value fields renamed accordingly
   - Update your code: 
     - `result.face_index` → `result.face_idx`
     - `vf.id` → `vf.face_idx`
-  - This change improves consistency across the entire API
+    - `vf.f` → `vf.view_factor`
+    - `vf.d` → `vf.distance`
+    - `vf.d̂` → `vf.direction`
+  - This change improves consistency and readability across the entire API
 
 ### Added
 - **Batch ray processing functionality** (#29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Standardized face index naming to `face_idx`** (pending PR)
   - All face index parameters renamed from `face_id` or `i` to `face_idx`
   - `RayShapeIntersectionResult.face_index` field renamed to `face_idx`
-  - Update your code: `result.face_index` → `result.face_idx`
+  - `VisibleFace.id` field renamed to `face_idx`
+  - Update your code: 
+    - `result.face_index` → `result.face_idx`
+    - `vf.id` → `vf.face_idx`
   - This change improves consistency across the entire API
 
 ### Added

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -156,7 +156,7 @@ ray = Ray(origin, direction)
 result = intersect_ray_shape(ray, shape)
 
 if result.hit
-    println("Ray hit face $(result.face_index) at distance $(result.distance).")
+    println("Ray hit face $(result.face_idx) at distance $(result.distance).")
     println("Hit point: ", result.point)
 else
     println("Ray missed the shape.")

--- a/src/face_visibility_graph.jl
+++ b/src/face_visibility_graph.jl
@@ -168,7 +168,7 @@ function get_visible_face_data(graph::FaceVisibilityGraph, face_idx::Int, idx::I
     
     base_idx = graph.row_ptr[face_idx] + idx - 1
     return (
-        id = graph.col_idx[base_idx],
+        face_idx = graph.col_idx[base_idx],
         f = graph.view_factors[base_idx],
         d = graph.distances[base_idx],
         d̂ = graph.directions[base_idx]

--- a/src/face_visibility_graph.jl
+++ b/src/face_visibility_graph.jl
@@ -168,10 +168,10 @@ function get_visible_face_data(graph::FaceVisibilityGraph, face_idx::Int, idx::I
     
     base_idx = graph.row_ptr[face_idx] + idx - 1
     return (
-        face_idx = graph.col_idx[base_idx],
-        f = graph.view_factors[base_idx],
-        d = graph.distances[base_idx],
-        d̂ = graph.directions[base_idx]
+        face_idx    = graph.col_idx[base_idx],
+        view_factor = graph.view_factors[base_idx],
+        distance    = graph.distances[base_idx],
+        direction   = graph.directions[base_idx]
     )
 end
 

--- a/src/face_visibility_graph.jl
+++ b/src/face_visibility_graph.jl
@@ -110,63 +110,63 @@ end
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 # Internal helper function to get the range of indices for a face
-function _get_visible_face_range(graph::FaceVisibilityGraph, face_id::Int)
-    @boundscheck 1 ≤ face_id ≤ graph.nfaces || throw(BoundsError(graph, face_id))
-    start_idx = graph.row_ptr[face_id]
-    end_idx   = graph.row_ptr[face_id + 1] - 1
+function _get_visible_face_range(graph::FaceVisibilityGraph, face_idx::Int)
+    @boundscheck 1 ≤ face_idx ≤ graph.nfaces || throw(BoundsError(graph, face_idx))
+    start_idx = graph.row_ptr[face_idx]
+    end_idx   = graph.row_ptr[face_idx + 1] - 1
     return start_idx:end_idx
 end
 
 """
-    get_visible_face_indices(graph::FaceVisibilityGraph, face_id::Int) -> SubArray
+    get_visible_face_indices(graph::FaceVisibilityGraph, face_idx::Int) -> SubArray
 
 Get indices of faces visible from the specified face.
 """
-function get_visible_face_indices(graph::FaceVisibilityGraph, face_id::Int)
-    range = _get_visible_face_range(graph, face_id)
+function get_visible_face_indices(graph::FaceVisibilityGraph, face_idx::Int)
+    range = _get_visible_face_range(graph, face_idx)
     return @view graph.col_idx[range]
 end
 
 """
-    get_view_factors(graph::FaceVisibilityGraph, face_id::Int) -> SubArray
+    get_view_factors(graph::FaceVisibilityGraph, face_idx::Int) -> SubArray
 
 Get view factors for the specified face.
 """
-function get_view_factors(graph::FaceVisibilityGraph, face_id::Int)
-    range = _get_visible_face_range(graph, face_id)
+function get_view_factors(graph::FaceVisibilityGraph, face_idx::Int)
+    range = _get_visible_face_range(graph, face_idx)
     return @view graph.view_factors[range]
 end
 
 """
-    get_visible_face_distances(graph::FaceVisibilityGraph, face_id::Int) -> SubArray
+    get_visible_face_distances(graph::FaceVisibilityGraph, face_idx::Int) -> SubArray
 
 Get distances to visible faces from the specified face.
 """
-function get_visible_face_distances(graph::FaceVisibilityGraph, face_id::Int)
-    range = _get_visible_face_range(graph, face_id)
+function get_visible_face_distances(graph::FaceVisibilityGraph, face_idx::Int)
+    range = _get_visible_face_range(graph, face_idx)
     return @view graph.distances[range]
 end
 
 """
-    get_visible_face_directions(graph::FaceVisibilityGraph, face_id::Int) -> SubArray
+    get_visible_face_directions(graph::FaceVisibilityGraph, face_idx::Int) -> SubArray
 
 Get direction vectors to visible faces from the specified face.
 """
-function get_visible_face_directions(graph::FaceVisibilityGraph, face_id::Int)
-    range = _get_visible_face_range(graph, face_id)
+function get_visible_face_directions(graph::FaceVisibilityGraph, face_idx::Int)
+    range = _get_visible_face_range(graph, face_idx)
     return @view graph.directions[range]
 end
 
 """
-    get_visible_face_data(graph::FaceVisibilityGraph, face_id::Int, idx::Int)
+    get_visible_face_data(graph::FaceVisibilityGraph, face_idx::Int, idx::Int)
 
 Get the idx-th visible face data for the specified face.
 """
-function get_visible_face_data(graph::FaceVisibilityGraph, face_id::Int, idx::Int)
-    visible_faces = get_visible_face_indices(graph, face_id)
+function get_visible_face_data(graph::FaceVisibilityGraph, face_idx::Int, idx::Int)
+    visible_faces = get_visible_face_indices(graph, face_idx)
     @boundscheck 1 ≤ idx ≤ length(visible_faces) || throw(BoundsError())
     
-    base_idx = graph.row_ptr[face_id] + idx - 1
+    base_idx = graph.row_ptr[face_idx] + idx - 1
     return (
         id = graph.col_idx[base_idx],
         f = graph.view_factors[base_idx],
@@ -176,11 +176,11 @@ function get_visible_face_data(graph::FaceVisibilityGraph, face_id::Int, idx::In
 end
 
 """
-    num_visible_faces(graph::FaceVisibilityGraph, face_id::Int) -> Int
+    num_visible_faces(graph::FaceVisibilityGraph, face_idx::Int) -> Int
 
 Get the number of visible faces for the specified face.
 """
-function num_visible_faces(graph::FaceVisibilityGraph, face_id::Int)
-    @boundscheck 1 ≤ face_id ≤ graph.nfaces || throw(BoundsError(graph, face_id))
-    return graph.row_ptr[face_id + 1] - graph.row_ptr[face_id]
+function num_visible_faces(graph::FaceVisibilityGraph, face_idx::Int)
+    @boundscheck 1 ≤ face_idx ≤ graph.nfaces || throw(BoundsError(graph, face_idx))
+    return graph.row_ptr[face_idx + 1] - graph.row_ptr[face_idx]
 end

--- a/src/ray_intersection.jl
+++ b/src/ray_intersection.jl
@@ -100,14 +100,14 @@ function intersect_ray_triangle(ray::Ray, v1::AbstractVector{<:Real}, v2::Abstra
 end
 
 """
-    intersect_ray_triangle(ray::Ray, shape::ShapeModel, face_id::Integer) -> RayTriangleIntersectionResult
+    intersect_ray_triangle(ray::Ray, shape::ShapeModel, face_idx::Integer) -> RayTriangleIntersectionResult
 
 Perform ray-triangle intersection test for a specific face in a shape model.
 
 # Arguments
-- `ray`: Ray with origin and direction
-- `shape`: Shape model containing the triangle
-- `face_id`: Index of the face to test (1-based)
+- `ray`      : Ray with origin and direction
+- `shape`    : Shape model containing the triangle
+- `face_idx` : Index of the face to test (1-based)
 
 # Returns
 - `RayTriangleIntersectionResult` object containing the intersection test result
@@ -125,20 +125,20 @@ ray = Ray(SA[0.0, 0.0, 100.0], SA[0.0, 0.0, -1.0])
 result = intersect_ray_triangle(ray, shape, 1)  # Test first face
 ```
 """
-@inline function intersect_ray_triangle(ray::Ray, shape::ShapeModel, face_id::Integer)
-    return intersect_ray_triangle(ray, shape.nodes, shape.faces, face_id)
+@inline function intersect_ray_triangle(ray::Ray, shape::ShapeModel, face_idx::Integer)
+    return intersect_ray_triangle(ray, shape.nodes, shape.faces, face_idx)
 end
 
 """
-    intersect_ray_triangle(ray::Ray, nodes::AbstractVector, faces::AbstractVector, face_id::Integer) -> RayTriangleIntersectionResult
+    intersect_ray_triangle(ray::Ray, nodes::AbstractVector, faces::AbstractVector, face_idx::Integer) -> RayTriangleIntersectionResult
 
 Perform ray-triangle intersection test for a specific face given nodes and faces arrays.
 
 # Arguments
-- `ray`: Ray with origin and direction
-- `nodes`: Array of node positions (3D vectors)
-- `faces`: Array of face definitions (each face is an array of 3 node indices)
-- `face_id`: Index of the face to test (1-based)
+- `ray`      : Ray with origin and direction
+- `nodes`    : Array of node positions (3D vectors)
+- `faces`    : Array of face definitions (each face is an array of 3 node indices)
+- `face_idx` : Index of the face to test (1-based)
 
 # Returns
 - `RayTriangleIntersectionResult` object containing the intersection test result
@@ -153,8 +153,8 @@ This function uses the same Möller-Trumbore algorithm as the base implementatio
 This is a lower-level interface useful when working directly with node and face arrays
 without a full `ShapeModel` structure.
 """
-@inline function intersect_ray_triangle(ray::Ray, nodes::AbstractVector, faces::AbstractVector, face_id::Integer)
-    v1, v2, v3 = get_face_nodes(nodes, faces, face_id)
+@inline function intersect_ray_triangle(ray::Ray, nodes::AbstractVector, faces::AbstractVector, face_idx::Integer)
+    v1, v2, v3 = get_face_nodes(nodes, faces, face_idx)
     return intersect_ray_triangle(ray, v1, v2, v3)
 end
 

--- a/src/ray_intersection.jl
+++ b/src/ray_intersection.jl
@@ -264,7 +264,7 @@ ray = Ray(SA[0.0, 0.0, 1000.0], SA[0.0, 0.0, -1.0])
 result = intersect_ray_shape(ray, shape)
 
 if result.hit
-    println("Hit face \$(result.face_index) at distance \$(result.distance)")
+    println("Hit face \$(result.face_idx) at distance \$(result.distance)")
 end
 ```
 """

--- a/src/shape_operations.jl
+++ b/src/shape_operations.jl
@@ -290,13 +290,13 @@ minimum_radius(shape::ShapeModel) = minimum_radius(shape.nodes)
 
 # Implementation of get_face_nodes for ShapeModel (declared in face_properties.jl)
 """
-    get_face_nodes(shape::ShapeModel, face_id::Integer) -> (v1, v2, v3)
+    get_face_nodes(shape::ShapeModel, face_idx::Integer) -> (v1, v2, v3)
 
 Extract three nodes of a triangular face from a shape model.
 
 # Arguments
-- `shape`: Shape model containing nodes and faces
-- `face_id`: Index of the face in the shape model
+- `shape`    : Shape model containing nodes and faces
+- `face_idx` : Index of the face in the shape model
 
 # Returns
 - Tuple of three nodes (v1, v2, v3)
@@ -309,6 +309,6 @@ v1, v2, v3 = get_face_nodes(shape, 1)  # Get nodes of the first face
 
 See also: [`get_face_nodes(nodes, faces, face_idx)`](@ref)
 """
-@inline function AsteroidShapeModels.get_face_nodes(shape::ShapeModel, face_id::Integer)
-    return get_face_nodes(shape.nodes, shape.faces, face_id)
+@inline function AsteroidShapeModels.get_face_nodes(shape::ShapeModel, face_idx::Integer)
+    return get_face_nodes(shape.nodes, shape.faces, face_idx)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -114,16 +114,16 @@ end
 Structure representing the result of ray-shape intersection test.
 
 # Fields
-- `hit`        : true if intersection exists, false otherwise
-- `distance`   : Distance from ray origin to intersection point
-- `point`      : Coordinates of the intersection point
-- `face_index` : Index of the intersected face
+- `hit`      : true if intersection exists, false otherwise
+- `distance` : Distance from ray origin to intersection point
+- `point`    : Coordinates of the intersection point
+- `face_idx` : Index of the intersected face
 """
 struct RayShapeIntersectionResult
     hit::Bool
     distance::Float64
     point::SVector{3, Float64}
-    face_index::Int
+    face_idx::Int
 end
 
 const NO_INTERSECTION_RAY_SHAPE = RayShapeIntersectionResult(false, NaN, SVector(NaN, NaN, NaN), 0)
@@ -141,7 +141,7 @@ function Base.show(io::IO, result::RayShapeIntersectionResult)
         print(io, "    ∘ hit        = $(result.hit)\n")
         print(io, "    ∘ distance   = $(result.distance)\n")
         print(io, "    ∘ point      = $(result.point)\n")
-        print(io, "    ∘ face_index = $(result.face_index)\n")
+        print(io, "    ∘ face_idx = $(result.face_idx)\n")
     else
         print(io, "Ray-Shape Intersection:\n")
         print(io, "    ∘ hit = $(result.hit)\n")

--- a/src/types.jl
+++ b/src/types.jl
@@ -138,9 +138,9 @@ Displays hit status and intersection details including face index if hit occurre
 function Base.show(io::IO, result::RayShapeIntersectionResult)
     if result.hit
         print(io, "Ray-Shape Intersection:\n")
-        print(io, "    ∘ hit        = $(result.hit)\n")
-        print(io, "    ∘ distance   = $(result.distance)\n")
-        print(io, "    ∘ point      = $(result.point)\n")
+        print(io, "    ∘ hit      = $(result.hit)\n")
+        print(io, "    ∘ distance = $(result.distance)\n")
+        print(io, "    ∘ point    = $(result.point)\n")
         print(io, "    ∘ face_idx = $(result.face_idx)\n")
     else
         print(io, "Ray-Shape Intersection:\n")

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,18 +21,18 @@ This type is used temporarily in `build_face_visibility_graph!` before convertin
 to the CSR format `FaceVisibilityGraph`.
 
 # Fields
-- `id` : Index of the interfacing face
-- `f`  : View factor from face i to j
-- `d`  : Distance from face i to j
-- `d̂`  : Normal vector from face i to j
+- `face_idx` : Index of the interfacing face
+- `f`        : View factor from face i to j
+- `d`        : Distance from face i to j
+- `d̂`        : Normal vector from face i to j
 
 Note: This is an internal type and not exported.
 """
 struct VisibleFace
-    id::Int64
-    f ::Float64
-    d ::Float64
-    d̂ ::SVector{3, Float64}
+    face_idx ::Int64
+    f        ::Float64
+    d        ::Float64
+    d̂        ::SVector{3, Float64}
 end
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,18 +21,18 @@ This type is used temporarily in `build_face_visibility_graph!` before convertin
 to the CSR format `FaceVisibilityGraph`.
 
 # Fields
-- `face_idx` : Index of the interfacing face
-- `f`        : View factor from face i to j
-- `d`        : Distance from face i to j
-- `d̂`        : Normal vector from face i to j
+- `face_idx`    : Index of the interfacing face
+- `view_factor` : View factor from face i to j
+- `distance`    : Distance from face i to j
+- `direction`   : Unit direction vector from face i to j
 
 Note: This is an internal type and not exported.
 """
 struct VisibleFace
-    face_idx ::Int64
-    f        ::Float64
-    d        ::Float64
-    d̂        ::SVector{3, Float64}
+    face_idx    ::Int64
+    view_factor ::Float64
+    distance    ::Float64
+    direction   ::SVector{3, Float64}
 end
 
 """

--- a/src/visibility.jl
+++ b/src/visibility.jl
@@ -230,14 +230,14 @@ Enum representing the eclipse status between binary pairs.
 end
 
 """
-    isilluminated(shape::ShapeModel, r☉::StaticVector{3}, i::Integer; with_self_shadowing::Bool) -> Bool
+    isilluminated(shape::ShapeModel, r☉::StaticVector{3}, face_idx::Integer; with_self_shadowing::Bool) -> Bool
 
 Check if a face is illuminated by the sun.
 
 # Arguments
-- `shape` : Shape model of an asteroid
-- `r☉`    : Sun's position in the asteroid-fixed frame
-- `i`     : Index of the face to be checked
+- `shape`    : Shape model of an asteroid
+- `r☉`       : Sun's position in the asteroid-fixed frame
+- `face_idx` : Index of the face to be checked
 
 # Keyword Arguments
 - `with_self_shadowing::Bool` : Whether to include self-shadowing effects.
@@ -251,30 +251,30 @@ Check if a face is illuminated by the sun.
 # Examples
 ```julia
 # Without self-shadowing (pseudo-convex model)
-illuminated = isilluminated(shape, sun_position, face_id; with_self_shadowing=false)
+illuminated = isilluminated(shape, sun_position, face_idx; with_self_shadowing=false)
 
 # With self-shadowing
-illuminated = isilluminated(shape, sun_position, face_id; with_self_shadowing=true)
+illuminated = isilluminated(shape, sun_position, face_idx; with_self_shadowing=true)
 ```
 """
-function isilluminated(shape::ShapeModel, r☉::StaticVector{3}, i::Integer; with_self_shadowing::Bool)
+function isilluminated(shape::ShapeModel, r☉::StaticVector{3}, face_idx::Integer; with_self_shadowing::Bool)
     if with_self_shadowing
         @assert !isnothing(shape.face_visibility_graph) "face_visibility_graph is required for self-shadowing. Build it using `build_face_visibility_graph!(shape)`."
-        return isilluminated_with_self_shadowing(shape, r☉, i)
+        return isilluminated_with_self_shadowing(shape, r☉, face_idx)
     else
-        return isilluminated_pseudo_convex(shape, r☉, i)
+        return isilluminated_pseudo_convex(shape, r☉, face_idx)
     end
 end
 
 """
-    isilluminated_pseudo_convex(shape::ShapeModel, r☉::StaticVector{3}, i::Integer) -> Bool
+    isilluminated_pseudo_convex(shape::ShapeModel, r☉::StaticVector{3}, face_idx::Integer) -> Bool
 
 Check if a face is illuminated using pseudo-convex model (face orientation only).
 
 # Arguments
-- `shape` : Shape model of an asteroid
-- `r☉`    : Sun's position in the asteroid-fixed frame (doesn't need to be normalized)
-- `i`     : Index of the face to be checked
+- `shape`    : Shape model of an asteroid
+- `r☉`       : Sun's position in the asteroid-fixed frame (doesn't need to be normalized)
+- `face_idx` : Index of the face to be checked
 
 # Description
 This function checks only if the face is oriented towards the sun, without any
@@ -287,21 +287,21 @@ This function ignores `face_visibility_graph` even if it exists.
 - `true` if the face is oriented towards the sun
 - `false` if the face is facing away from the sun
 """
-function isilluminated_pseudo_convex(shape::ShapeModel, r☉::StaticVector{3}, i::Integer)::Bool
-    n̂ᵢ = shape.face_normals[i]
+function isilluminated_pseudo_convex(shape::ShapeModel, r☉::StaticVector{3}, face_idx::Integer)::Bool
+    n̂ᵢ = shape.face_normals[face_idx]
     r̂☉ = normalize(r☉)
     return n̂ᵢ ⋅ r̂☉ > 0
 end
 
 """
-    isilluminated_with_self_shadowing(shape::ShapeModel, r☉::StaticVector{3}, i::Integer) -> Bool
+    isilluminated_with_self_shadowing(shape::ShapeModel, r☉::StaticVector{3}, face_idx::Integer) -> Bool
 
 Check if a face is illuminated with self-shadowing effects.
 
 # Arguments
-- `shape` : Shape model with `face_visibility_graph` (required)
-- `r☉`    : Sun's position in the asteroid-fixed frame (doesn't need to be normalized)
-- `i`     : Index of the face to be checked
+- `shape`    : Shape model with `face_visibility_graph` (required)
+- `r☉`       : Sun's position in the asteroid-fixed frame (doesn't need to be normalized)
+- `face_idx` : Index of the face to be checked
 
 # Description
 This function performs full illumination calculation including self-shadowing effects.
@@ -313,11 +313,11 @@ If `face_visibility_graph` is not available, this function will throw an error.
 - `true` if the face is illuminated (facing the sun and not occluded)
 - `false` if the face is facing away from the sun or is in shadow
 """
-function isilluminated_with_self_shadowing(shape::ShapeModel, r☉::StaticVector{3}, i::Integer)::Bool
+function isilluminated_with_self_shadowing(shape::ShapeModel, r☉::StaticVector{3}, face_idx::Integer)::Bool
     @assert !isnothing(shape.face_visibility_graph) "face_visibility_graph is required for self-shadowing. Build it using `build_face_visibility_graph!(shape)`."
     
-    cᵢ = shape.face_centers[i]
-    n̂ᵢ = shape.face_normals[i]
+    cᵢ = shape.face_centers[face_idx]
+    n̂ᵢ = shape.face_normals[face_idx]
     r̂☉ = normalize(r☉)
     
     # First check if the face is oriented away from the sun
@@ -325,7 +325,7 @@ function isilluminated_with_self_shadowing(shape::ShapeModel, r☉::StaticVector
     
     # Check for occlusions using face visibility graph
     ray = Ray(cᵢ, r̂☉)  # Ray from face center to the sun's position
-    visible_face_indices = get_visible_face_indices(shape.face_visibility_graph, i)
+    visible_face_indices = get_visible_face_indices(shape.face_visibility_graph, face_idx)
     for j in visible_face_indices
         intersect_ray_triangle(ray, shape, j).hit && return false
     end

--- a/src/visibility.jl
+++ b/src/visibility.jl
@@ -198,10 +198,10 @@ function build_face_visibility_graph!(shape::ShapeModel)
     idx = 1
     for i in 1:nfaces
         for vf in temp_visible[i]
-            col_idx[idx] = vf.face_idx
-            view_factors[idx] = vf.f
-            distances[idx] = vf.d
-            directions[idx] = vf.d̂
+            col_idx[idx]      = vf.face_idx
+            view_factors[idx] = vf.view_factor
+            distances[idx]    = vf.distance
+            directions[idx]   = vf.direction
             idx += 1
         end
     end

--- a/src/visibility.jl
+++ b/src/visibility.jl
@@ -150,7 +150,7 @@ function build_face_visibility_graph!(shape::ShapeModel)
         # Check visibility for each candidate face
         for (j, dᵢⱼ) in zip(candidates, distances)
             # Skip if already processed
-            j in (vf.id for vf in temp_visible[i]) && continue
+            j in (vf.face_idx for vf in temp_visible[i]) && continue
 
             cⱼ = face_centers[j]
             n̂ⱼ = face_normals[j]
@@ -198,7 +198,7 @@ function build_face_visibility_graph!(shape::ShapeModel)
     idx = 1
     for i in 1:nfaces
         for vf in temp_visible[i]
-            col_idx[idx] = vf.id
+            col_idx[idx] = vf.face_idx
             view_factors[idx] = vf.f
             distances[idx] = vf.d
             directions[idx] = vf.d̂

--- a/test/test_bvh_comprehensive.jl
+++ b/test/test_bvh_comprehensive.jl
@@ -71,7 +71,7 @@ All tests include correctness verification and performance benchmarks.
             
             if result.hit
                 hits += 1
-                println("  Ray $i: Hit face $(result.face_index) at distance $(round(result.distance, digits=2))")
+                println("  Ray $i: Hit face $(result.face_idx) at distance $(round(result.distance, digits=2))")
             end
         end
         

--- a/test/test_face_visibility_graph.jl
+++ b/test/test_face_visibility_graph.jl
@@ -89,10 +89,10 @@
         
         # get_visible_face_data
         data = get_visible_face_data(graph, 1, 1)
-        @test data.id == 2
-        @test data.f ≈ 0.1
-        @test data.d ≈ 1.0
-        @test data.d̂ ≈ SA[1.0, 0.0, 0.0]
+        @test data.face_idx == 2
+        @test data.view_factor ≈ 0.1
+        @test data.distance ≈ 1.0
+        @test data.direction ≈ SA[1.0, 0.0, 0.0]
     end
     
     # ╔═══════════════════════════════════════════════════════════════════╗

--- a/test/test_ray_intersection.jl
+++ b/test/test_ray_intersection.jl
@@ -151,7 +151,7 @@ This file verifies:
         
         # Verify results
         test_ray_intersection(result, true, 1.0, @SVector([0.25, 0.25, 0.0]))
-        @test result.face_index == 1  # Hit the first (and only) face
+        @test result.face_idx == 1  # Hit the first (and only) face
     end
     
     @testset "BVH Pre-build Requirement" begin
@@ -175,7 +175,7 @@ This file verifies:
         # Now intersection should work
         result = intersect_ray_shape(ray, shape_no_bvh)
         test_ray_intersection(result, true, 1.0, @SVector([0.25, 0.25, 0.0]))
-        @test result.face_index == 1
+        @test result.face_idx == 1
     end
     
     @testset "Batch Ray Intersection" begin
@@ -219,7 +219,7 @@ This file verifies:
             
             # Ray 1: Center hit
             @test results[1].hit == true
-            @test results[1].face_index == 1
+            @test results[1].face_idx == 1
             @test results[1].distance ≈ 1.0
             @test results[1].point ≈ SA[0.25, 0.25, 0.0]
             
@@ -228,7 +228,7 @@ This file verifies:
             
             # Ray 3: Hit
             @test results[3].hit == true
-            @test results[3].face_index == 1
+            @test results[3].face_idx == 1
             @test results[3].distance ≈ 1.0
             @test results[3].point ≈ SA[0.3, 0.1, 0.0]
             
@@ -237,7 +237,7 @@ This file verifies:
             
             # Ray 5: Hit from below
             @test results[5].hit == true
-            @test results[5].face_index == 1
+            @test results[5].face_idx == 1
             @test results[5].distance ≈ 1.0
             @test results[5].point ≈ SA[0.1, 0.1, 0.0]
         end


### PR DESCRIPTION
## Summary
Comprehensive standardization of face index and visibility-related naming conventions throughout the codebase.

## Changes

### Face Index Standardization
- Renamed all face index parameters from `face_id` or `i` to `face_idx`
- Updated corresponding documentation
- Kept loop variables as `i`, `j`, `k` following Julia conventions

### Struct Field Renaming
#### `RayShapeIntersectionResult`
- `face_index` → `face_idx`

#### `VisibleFace` (internal type)
- `id` → `face_idx`
- `f` → `view_factor`
- `d` → `distance`
- `d̂` → `direction`

#### `get_visible_face_data` return value
- Return fields renamed to match `VisibleFace` changes

## Affected Files
- `src/face_visibility_graph.jl` - Updated `get_visible_face_data` return fields
- `src/ray_intersection.jl` - Updated function parameters
- `src/shape_operations.jl` - Updated function parameters
- `src/visibility.jl` - Updated function parameters and `VisibleFace` usage
- `src/types.jl` - Changed struct field names
- `test/test_ray_intersection.jl` - Updated test code
- `test/test_bvh_comprehensive.jl` - Updated test code
- `docs/src/tutorial.md` - Updated documentation examples
- `CHANGELOG.md` - Added comprehensive breaking change entries

## Breaking Changes

### Public API
- `RayShapeIntersectionResult.face_index` → `face_idx`
- Users need to update: `result.face_index` → `result.face_idx`

### Internal API
- `VisibleFace` struct fields renamed (internal type)
- `get_visible_face_data` return value fields renamed
- Users of internal APIs need to update:
  - `vf.id` → `vf.face_idx`
  - `vf.f` → `vf.view_factor`
  - `vf.d` → `vf.distance`
  - `vf.d̂` → `vf.direction`

## Rationale
These changes improve code readability and maintain consistency across the entire codebase. The new field names are self-documenting and reduce the need for comments explaining what each field represents.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>