### PR TITLE
docs: Add migration guide and update documentation for v0.4.2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,9 +65,6 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
 ## Version 0.5.0 - Advanced Surface Modeling (Target: September 2025)
 
 ### Major Features
-- **Breaking Changes**
-  - [ ] Remove `use_elevation_optimization` parameter from illumination APIs
-  - [ ] Make face maximum elevation optimization the default implementation
 - **Hierarchical Surface Roughness Model**
   - [ ] Support nested shape models for multi-scale surface representation
   - [ ] Implement efficient traversal algorithms for nested structures
@@ -78,26 +75,24 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
   - [ ] Implement Fractal surface generation
   - [ ] Add comprehensive test coverage for roughness features
 
-- **Performance Enhancements**
-  - [ ] Add basic multi-threading support using `Threads.jl`
-  - [ ] Optimize critical paths for better single-threaded performance
-  - [ ] **Optimize `apply_eclipse_shadowing!` memory allocations**
-    - Current implementation calls `intersect_ray_shape` per face, causing ~200 allocations per call
-    - Implement true batch ray tracing with pre-allocated buffers for mutual shadowing
-    - Design `EclipseShadowingBuffer` struct to hold reusable arrays
-    - Implement filtering that preserves early-out optimizations
-    - Ensure zero allocations during runtime after initial buffer creation
-  - [ ] Add multi-threading support to `apply_eclipse_shadowing!` using `@threads`
-  - [ ] Implement spatial data structures (e.g., octree) to pre-filter potentially shadowed faces
-  - [ ] Add caching for temporal coherence in simulations with small time steps
-
 ### API Improvements
 - [ ] Remove deprecated `apply_eclipse_shadowing!` signature that uses `t₁₂` parameter
   - Old signature: `apply_eclipse_shadowing!(illuminated_faces, shape1, r☉₁, R₁₂, t₁₂, shape2)`
   - Keep only the new signature with `r₁₂` parameter introduced in v0.4.1
+- [ ] Remove `use_elevation_optimization` parameter from illumination APIs
+  - Make face maximum elevation optimization the default implementation
 - [ ] Unify parameter naming conventions across the package
 - [ ] Create configuration structs for complex operations
 - [ ] Improve error messages and validation
+
+### Performance Enhancements
+- [ ] **Optimize `apply_eclipse_shadowing!` memory allocations**
+  - Current implementation calls `intersect_ray_shape` per face, causing ~200 allocations per call
+  - Implement true batch ray tracing with pre-allocated buffers for mutual shadowing
+  - Design `EclipseShadowingBuffer` struct to hold reusable arrays
+  - Implement filtering that preserves early-out optimizations
+  - Ensure zero allocations during runtime after initial buffer creation
+- [ ] Add basic multi-threading support using `Threads.jl`
 
 ## Version 0.6.0 - High-Performance Computing Support (Target: October 2025)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,10 @@
 
 This document outlines the development plans and milestones for `AsteroidShapeModels.jl`. We use [Semantic Versioning](https://semver.org/) for version numbering.
 
+We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get involved.
+
+Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeModels.jl/issues) for current tasks and discussions.
+
 ## Version 0.4.0 - BVH Integration and Optimization (Released: July 2025)
 
 ### Major Changes (Breaking Changes)
@@ -121,16 +125,3 @@ This document outlines the development plans and milestones for `AsteroidShapeMo
 
 - **Extended File Format Support**
   - PLY/STL/VTK/DSK format support
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get involved.
-
-## Tracking Progress
-
-Development progress is tracked through:
-- GitHub Milestones for each version
-- GitHub Issues for specific features and bugs
-- Pull Requests for implementation
-
-Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeModels.jl/issues) for current tasks and discussions.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 
 Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeModels.jl/issues) for current tasks and discussions.
 
-## Version 0.4.0 - BVH Integration and Optimization (Released: July 2025)
+## Version 0.4.0 - BVH Integration and Optimization (Released: 2025-07-08)
 
 ### Major Changes (Breaking Changes)
 - **Full Integration of `ImplicitBVH.jl`**
@@ -30,7 +30,7 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
 - [x] Add comprehensive BVH usage documentation
 - [x] Update examples for new APIs
 
-## Version 0.4.1 - API Improvements (Released: July 2025)
+## Version 0.4.1 - API Improvements (Released: 2025-07-10)
 
 ### Completed
 - **Improved `apply_eclipse_shadowing!` API**
@@ -45,7 +45,7 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
     - Now correctly recovers shape2's position using `r₁₂ = -R₁₂' * t₁₂`
   - [x] Fixed sun position transformation in eclipse shadowing (include rotation + translation)
 
-## Version 0.4.2 - Performance Optimizations (Target: August 2025)
+## Version 0.4.2 - Performance Optimizations (Released: 2025-07-21)
 
 ### Performance Features
 - **Face Maximum Elevation Precomputation**

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(;
         "Tutorial" => "tutorial.md",
         "Guides" => [
             "BVH Usage" => "guides/bvh_usage.md",
+            "Migration Guide" => "guides/migration.md",
         ],
         "API Reference" => [
             "Types" => "api/types.md",

--- a/docs/src/guides/migration.md
+++ b/docs/src/guides/migration.md
@@ -1,0 +1,103 @@
+# Migration Guide
+
+This guide helps you migrate your code when upgrading between major versions of `AsteroidShapeModels.jl`.
+
+## Migrating to v0.4.2
+
+### New Performance Features
+
+#### Face Maximum Elevation Optimization
+
+The v0.4.2 release includes automatic performance optimizations for illumination calculations. No code changes are required to benefit from these improvements.
+
+```julia
+# Your existing code works as before, but ~2.5x faster!
+illuminated = isilluminated(shape, sun_position, face_idx; with_self_shadowing=true)
+```
+
+To disable the optimization (not recommended):
+```julia
+# Explicitly disable optimization
+illuminated = isilluminated(
+   shape, sun_position, face_idx; 
+   with_self_shadowing=true, 
+   use_elevation_optimization=false,
+)
+```
+
+## Migrating to v0.4.1
+
+### Breaking Changes
+
+#### New `apply_eclipse_shadowing!` API
+
+The parameter order has been changed for better SPICE integration:
+
+```julia
+# Old API (deprecated)
+apply_eclipse_shadowing!(illuminated_faces, shape1, r☉₁, R₁₂, t₁₂, shape2)
+
+# New API (recommended)
+apply_eclipse_shadowing!(illuminated_faces, shape1, shape2, r☉₁, r₁₂, R₁₂)
+```
+
+Key differences:
+- `shape1` and `shape2` are now grouped together
+- `r₁₂` (shape2's position in shape1's frame) replaces `t₁₂`
+- More intuitive parameter ordering
+
+Migration example:
+```julia
+# If you have t₁₂, convert it to r₁₂:
+r₁₂ = -R₁₂' * t₁₂
+
+# Then use the new API:
+apply_eclipse_shadowing!(illuminated, shape1, shape2, sun_position, r₁₂, R₁₂)
+```
+
+## Migrating to v0.4.0
+
+### New Unified Illumination API
+
+The illumination functions have been unified into a single API:
+
+```julia
+# Old APIs (removed)
+isilluminated_pseudoconvex(shape, sun_position, face_idx)
+isilluminated_with_self_shadowing(shape, sun_position, face_idx)
+
+# New unified API
+isilluminated(shape, sun_position, face_idx; with_self_shadowing=false)  # pseudo-convex
+isilluminated(shape, sun_position, face_idx; with_self_shadowing=true)   # with shadowing
+```
+
+### Batch Processing
+
+New batch processing functions for better performance:
+
+```julia
+# Process all faces at once
+illuminated = Vector{Bool}(undef, length(shape.faces))
+update_illumination!(illuminated, shape, sun_position; with_self_shadowing=true)
+```
+
+## Future Deprecations (v0.5.0)
+
+### Planned Removals
+
+1. **`use_elevation_optimization` parameter**
+   - Will be removed in v0.5.0
+   - Optimization will become the default behavior
+   - Start removing explicit `use_elevation_optimization=true` from your code
+
+2. **Old `apply_eclipse_shadowing!` signature**
+   - The deprecated signature with `t₁₂` will be removed
+   - Migrate to the new API with `r₁₂` parameter
+
+## Getting Help
+
+If you encounter issues during migration:
+
+1. Check the [CHANGELOG](https://github.com/Astroshaper/AsteroidShapeModels.jl/blob/main/CHANGELOG.md) for detailed changes
+2. Review the [API documentation](https://astroshaper.github.io/AsteroidShapeModels.jl/stable)
+3. Open an [issue](https://github.com/Astroshaper/AsteroidShapeModels.jl/issues) on GitHub


### PR DESCRIPTION
## Summary

This PR adds a comprehensive migration guide and updates documentation for the v0.4.2 release.

## Changes

### 1. Migration Guide (`docs/src/guides/migration.md`)
- Comprehensive guide for migrating between versions
- Instructions for v0.4.2 performance features
- v0.4.1 breaking changes (`apply_eclipse_shadowing!` API)
- v0.4.0 unified illumination API
- Future deprecations planned for v0.5.0

### 2. README Updates
- Reorganized Key Features section for better clarity
- Added "What's New in v0.4.2" section
- Improved Quick Start examples organization
- Replaced inline migration guide with link to comprehensive guide
- General cleanup and improved structure

### 3. ROADMAP Updates
- Marked v0.4.2 as released
- Updated PR references for completed tasks
- Cleaned up formatting

## Documentation Structure

The migration guide is now part of the official documentation:
```
docs/src/guides/
├── bvh_usage.md
└── migration.md  ← New comprehensive migration guide
```

🤖 Generated with [Claude Code](https://claude.ai/code)