### PR TITLE
feat: Add `HierarchicalShapeModel` for surface roughness representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,27 @@ All notable changes to `AsteroidShapeModels.jl` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+---
+
 ## [Unreleased]
+
+### Added
+- **Hierarchical shape models for multi-scale surface representation** (PR TBD)
+  - New `HierarchicalShapeModel` type that supports adding surface roughness to a base shape model
+  - Roughness model management functions:
+    - `has_roughness_model` - Check if a face has associated roughness
+    - `get_roughness_model` - Retrieve roughness model for a face
+    - `get_roughness_model_scale` - Get scale factor for roughness model
+    - `get_roughness_model_transform` - Get affine transformation for roughness model
+    - `add_roughness_models!` - Add roughness models to faces (supports both all-faces and specific-face variants)
+    - `clear_roughness_models!` - Remove roughness models from faces (supports both all-faces and specific-face variants)
+  - Coordinate transformation functions:
+    - `transform_point_global_to_local` / `transform_point_local_to_global` - Transform points between coordinate systems (full affine transformation)
+    - `transform_geometric_vector_global_to_local` / `transform_geometric_vector_local_to_global` - Transform geometric vectors (with scaling)
+    - `transform_physical_vector_global_to_local` / `transform_physical_vector_local_to_global` - Transform physical vectors (rotation only)
+  - Memory-efficient design allowing multiple faces to share the same roughness model
+  - Automatic north-aligned local coordinate system for each face
+  - Support for custom affine transformations per face
 
 ### Breaking Changes
 - **Removed deprecated `apply_eclipse_shadowing!` signature** (#51)
@@ -18,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Elevation-based optimization is now always enabled when `with_self_shadowing=true`
   - Affected functions: `isilluminated`, `update_illumination!`
   - This simplifies the API and ensures users always get the best performance
+
+---
 
 ## [0.4.2] - 2025-01-21
 
@@ -48,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Better separation of concerns between geometric calculations and eclipse logic
   - Performance is identical but code is more maintainable
 
+---
+
 ## [0.4.1] - 2025-07-10
 
 ### Added
@@ -74,6 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Now correctly includes translation when transforming sun position to shape2's frame
   - Previously only applied rotation, which could lead to incorrect shadow calculations
   - Ensures accurate eclipse detection in binary asteroid systems
+
+---
 
 ## [0.4.0] - 2025-07-07
 
@@ -152,6 +178,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated file-level documentation in `visibility.jl` with new exported functions
 - Updated package structure documentation to reflect new file organization
 
+---
+
 ## [0.3.1] - 2025-07-02
 
 ### Added
@@ -180,6 +208,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backward compatible - no breaking changes
 - BVH support is opt-in and does not affect existing code
 - Current BVH visibility implementation has room for future optimization
+
+---
 
 ## [0.3.0] - 2025-06-20
 
@@ -261,6 +291,8 @@ The new CSR-based implementation provides:
 - ~50% memory reduction across all model sizes
 - Better cache locality for sequential access patterns
 
+---
+
 ## [0.2.1] - 2025-06-17
 
 ### Added
@@ -277,6 +309,8 @@ The new CSR-based implementation provides:
 ### Deprecated
 - Legacy adjacency list implementation will be removed in v0.3.0
 - `shape.visiblefacets` field will be removed in v0.3.0 (use `shape.visibility_graph`)
+
+---
 
 ## [0.2.0] - 2025-06-14
 
@@ -312,6 +346,8 @@ The new CSR-based implementation provides:
 - Added PkgEval badge to README
 - Updated installation instructions for Julia General registry
 - Added Julia REPL package mode installation method
+
+---
 
 ## [0.1.0] - Initial Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.4.2] - 2025-01-21
+## [0.4.2] - 2025-07-21
 
 ### Added
 - **Face maximum elevation optimization for faster illumination calculations** (#46)
@@ -101,7 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.4.0] - 2025-07-07
+## [0.4.0] - 2025-07-08
 
 ### Breaking Changes
 - **BVH must be pre-built for ray intersection** (04d2937, 5355dbc)

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Masanori Kanamaru <kanamaru-masanori@hotmail.co.jp>"]
 version = "0.4.2"
 
 [deps]
+CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 ImplicitBVH = "932a18dc-bb55-4cd5-bdd6-1368ec9cea29"
@@ -13,6 +14,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 BenchmarkTools = "1.6.0"
+CoordinateTransformations = "0.6"
 FileIO = "1"
 GeometryBasics = "0.5"
 ImplicitBVH = "0.6.0"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,8 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 
 Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeModels.jl/issues) for current tasks and discussions.
 
+---
+
 ## Version 0.4.0 - BVH Integration and Optimization (Released: 2025-07-08)
 
 ### Major Changes (Breaking Changes)
@@ -30,6 +32,8 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
 - [x] Add comprehensive BVH usage documentation
 - [x] Update examples for new APIs
 
+---
+
 ## Version 0.4.1 - API Improvements (Released: 2025-07-10)
 
 ### Completed
@@ -44,6 +48,8 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
     - This caused false TOTAL_ECLIPSE detections when shape2 was actually behind shape1
     - Now correctly recovers shape2's position using `r₁₂ = -R₁₂' * t₁₂`
   - [x] Fixed sun position transformation in eclipse shadowing (include rotation + translation)
+
+---
 
 ## Version 0.4.2 - Performance Optimizations (Released: 2025-07-21)
 
@@ -61,6 +67,8 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
 - **Improve `apply_eclipse_shadowing!` code readability**
   - [x] Extract ray-sphere intersection tests into dedicated reusable functions (#45)
   - [x] Ensure consistency in results with previous implementation (#45)
+
+---
 
 ## Version 0.5.0 - Advanced Surface Modeling (Target: September 2025)
 
@@ -94,6 +102,8 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
   - Ensure zero allocations during runtime after initial buffer creation
 - [ ] Add basic multi-threading support using `Threads.jl`
 
+---
+
 ## Version 0.6.0 - High-Performance Computing Support (Target: October 2025)
 
 ### Major Features
@@ -112,6 +122,8 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
 - [ ] Support for extremely large models (3M faces)
 - [ ] Memory-efficient algorithms for resource-constrained environments
 - [ ] Streaming processing for models that don't fit in memory
+
+---
 
 ## Future Considerations (Beyond v0.6.0)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,12 +70,11 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
 
 ---
 
-## Version 0.5.0 - Advanced Surface Modeling (Target: September 2025)
+## Version 0.5.0 - Surface Roughness Modeling (Target: September 2025)
 
 ### Major Features
-- **Hierarchical Surface Roughness Model**
-  - [ ] Support nested shape models for multi-scale surface representation
-  - [ ] Implement efficient traversal algorithms for nested structures
+- **Hierarchical Shape Model**
+  - [ ] Support nested shape models for surface roughness representation
   
 - **Complete Roughness Module**
   - [ ] Implement parallel sinusoidal trench generation

--- a/docs/src/api/roughness.md
+++ b/docs/src/api/roughness.md
@@ -4,6 +4,30 @@
 CurrentModule = AsteroidShapeModels
 ```
 
+## Hierarchical Shape Models
+
+### Roughness Model Management
+
+```@docs
+has_roughness_model
+get_roughness_model
+get_roughness_model_scale
+get_roughness_model_transform
+add_roughness_models!
+clear_roughness_models!
+```
+
+### Coordinate Transformations
+
+```@docs
+transform_point_global_to_local
+transform_point_local_to_global
+transform_geometric_vector_global_to_local
+transform_geometric_vector_local_to_global
+transform_physical_vector_global_to_local
+transform_physical_vector_local_to_global
+```
+
 ## Crater Modeling
 
 ```@docs

--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -8,6 +8,7 @@ CurrentModule = AsteroidShapeModels
 
 ```@docs
 ShapeModel
+HierarchicalShapeModel
 Ray
 Sphere
 ```

--- a/docs/src/api/types.md
+++ b/docs/src/api/types.md
@@ -7,6 +7,7 @@ CurrentModule = AsteroidShapeModels
 ## Core Types
 
 ```@docs
+AbstractShapeModel
 ShapeModel
 HierarchicalShapeModel
 Ray

--- a/docs/src/guides/migration.md
+++ b/docs/src/guides/migration.md
@@ -16,6 +16,32 @@ No planned deprecations at this time.
 
 ## Migrating to v0.5.0 (Unreleased)
 
+### New Features
+
+#### Hierarchical Shape Models
+
+v0.5.0 introduces `HierarchicalShapeModel` for multi-scale surface representation:
+
+```julia
+# Create hierarchical model from global shape
+hier_shape = HierarchicalShapeModel(global_shape)
+
+# Add roughness models to specific faces
+roughness = load_shape_obj("roughness.obj", scale=10)
+add_roughness_models!(hier_shape, roughness, face_idx; scale=0.01)
+
+# Transform between global and local coordinates
+p_local = transform_point_global_to_local(hier_shape, face_idx, p_global)
+v_local = transform_geometric_vector_global_to_local(hier_shape, face_idx, v_global)
+f_local = transform_physical_vector_global_to_local(hier_shape, face_idx, f_global)
+```
+
+Key features:
+- Add surface roughness models to individual faces
+- Automatic coordinate transformations between global and local frames
+- Separate handling of geometric vectors (with scaling) and physical vectors (rotation only)
+- Memory-efficient sharing of roughness models across multiple faces
+
 ### Breaking Changes
 
 #### Removed `apply_eclipse_shadowing!` deprecated signature

--- a/src/AsteroidShapeModels.jl
+++ b/src/AsteroidShapeModels.jl
@@ -61,7 +61,7 @@ include("hierarchical_shape_model.jl")
 export HierarchicalShapeModel
 export add_roughness_models!, clear_roughness_models!, get_roughness_model, get_roughness_model_scale, get_roughness_model_transform, has_roughness_model
 export transform_point_global_to_local, transform_point_local_to_global
-export transform_vector_global_to_local, transform_vector_local_to_global
+export transform_geometric_vector_global_to_local, transform_geometric_vector_local_to_global
 export transform_physical_vector_global_to_local, transform_physical_vector_local_to_global
 
 include("face_visibility_graph.jl")

--- a/src/AsteroidShapeModels.jl
+++ b/src/AsteroidShapeModels.jl
@@ -59,7 +59,8 @@ export AbstractShapeModel, ShapeModel, build_bvh!
 
 include("hierarchical_shape_model.jl")
 export HierarchicalShapeModel
-export add_roughness_models!, clear_roughness_models!, get_roughness_model, get_roughness_model_scale, get_roughness_model_transform, has_roughness_model
+export has_roughness_model, get_roughness_model, get_roughness_model_scale, get_roughness_model_transform
+export clear_roughness_models!, add_roughness_models!
 export transform_point_global_to_local, transform_point_local_to_global
 export transform_geometric_vector_global_to_local, transform_geometric_vector_local_to_global
 export transform_physical_vector_global_to_local, transform_physical_vector_local_to_global

--- a/src/AsteroidShapeModels.jl
+++ b/src/AsteroidShapeModels.jl
@@ -8,7 +8,9 @@ including loading from OBJ files, computing geometric properties, ray-shape inte
 visibility analysis, and surface roughness modeling.
 
 # Main Types
+- `AbstractShapeModel`: Abstract base type for all shape models
 - `ShapeModel`: Core data structure for polyhedral shapes
+- `HierarchicalShapeModel`: Multi-scale shape model with surface roughness
 - `Ray`: Ray for ray casting operations
 - `FaceVisibilityGraph`: CSR-style data structure for face-to-face visibility
 
@@ -52,7 +54,14 @@ export Ray, Sphere
 export RayTriangleIntersectionResult, RayShapeIntersectionResult, RaySphereIntersectionResult
 
 include("shape_model.jl")
-export ShapeModel, build_bvh!
+export AbstractShapeModel, ShapeModel, build_bvh!
+
+include("hierarchical_shape_model.jl")
+export HierarchicalShapeModel
+export add_roughness_model!, get_roughness_model, get_roughness_model_scale, has_roughness
+export transform_point_global_to_local, transform_point_local_to_global
+export transform_vector_global_to_local, transform_vector_local_to_global
+export transform_physical_vector_global_to_local, transform_physical_vector_local_to_global
 
 include("face_visibility_graph.jl")
 export FaceVisibilityGraph, build_face_visibility_graph!, view_factor

--- a/src/AsteroidShapeModels.jl
+++ b/src/AsteroidShapeModels.jl
@@ -59,7 +59,7 @@ export AbstractShapeModel, ShapeModel, build_bvh!
 
 include("hierarchical_shape_model.jl")
 export HierarchicalShapeModel
-export add_roughness_models!, clear_roughness_models!, get_roughness_model, get_roughness_model_scale, has_roughness_model
+export add_roughness_models!, clear_roughness_models!, get_roughness_model, get_roughness_model_scale, get_roughness_model_transform, has_roughness_model
 export transform_point_global_to_local, transform_point_local_to_global
 export transform_vector_global_to_local, transform_vector_local_to_global
 export transform_physical_vector_global_to_local, transform_physical_vector_local_to_global

--- a/src/AsteroidShapeModels.jl
+++ b/src/AsteroidShapeModels.jl
@@ -59,7 +59,7 @@ export AbstractShapeModel, ShapeModel, build_bvh!
 
 include("hierarchical_shape_model.jl")
 export HierarchicalShapeModel
-export add_roughness_model!, get_roughness_model, get_roughness_model_scale, has_roughness
+export add_roughness_models!, clear_roughness_models!, get_roughness_model, get_roughness_model_scale, has_roughness_model
 export transform_point_global_to_local, transform_point_local_to_global
 export transform_vector_global_to_local, transform_vector_local_to_global
 export transform_physical_vector_global_to_local, transform_physical_vector_local_to_global

--- a/src/AsteroidShapeModels.jl
+++ b/src/AsteroidShapeModels.jl
@@ -38,6 +38,7 @@ See the documentation for detailed usage examples and API reference.
 """
 module AsteroidShapeModels
 
+using CoordinateTransformations
 using FileIO
 using LinearAlgebra
 using StaticArrays

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -300,7 +300,7 @@ Add the same surface roughness model to all faces of the hierarchical shape mode
 # Notes
 - This function applies the roughness model to ALL faces, overwriting any existing assignments.
 - All faces will share the same ShapeModel instance, making this memory-efficient.
-- Appropriate transformations are automatically computed for each face using [`compute_face_roughness_transform`](@ref).
+- Appropriate transformations are automatically computed for each face using `compute_face_roughness_transform`.
 - Use the face-specific version `add_roughness_models!(hier_shape, roughness_model, face_idx; scale, transform)`
   to selectively apply different models to individual faces or to provide custom transformations.
 """
@@ -350,7 +350,7 @@ Add a surface roughness model to a specific face of the hierarchical shape model
 - `transform::Union{Nothing, AFFINE_MAP_TYPE}` :
         Affine transformation from global to local coordinates (optional).
         If `nothing` (default), automatically computes an appropriate transformation
-        using [`compute_face_roughness_transform`](@ref)
+        using `compute_face_roughness_transform`
 
 # Notes
 - If the face already has a roughness model, it will be replaced.

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -1,0 +1,316 @@
+#=
+    hierarchical_shape_model.jl
+
+Implements hierarchical shape models for multi-scale surface representation.
+This allows detailed surface features (craters, boulders, roughness) to be
+added to base shape models while maintaining computational efficiency.
+
+The hierarchical structure uses:
+- Base shape model (ShapeModel) for global geometry
+- Detail shape models (ShapeModel) for localized surface roughness
+- Transformation matrices and scales stored as arrays
+- Efficient indexing for O(1) access to face details
+=#
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                        Type Definition                            ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+"""
+    HierarchicalShapeModel <: AbstractShapeModel
+
+A shape model that supports multi-scale surface representation through surface roughness models.
+
+# Fields
+- `global_shape`           : `ShapeModel` to represent the global shape of the asteroid
+- `face_roughness_indices` : Mapping from face index to roughness model index (0 = no roughness)
+- `roughness_models`       : Vector of `ShapeModel` objects representing surface roughness
+- `roughness_model_scales` : Vector of scale factors for each roughness model
+
+# Description
+This structure allows representing asteroid surfaces at two scales:
+1. **Global scale**: The overall asteroid shape (`global_shape`)
+2. **Local scale**: Surface roughness models attached to individual faces (`roughness_models`)
+
+Each face of the global shape can have at most one roughness model attached to it.
+The `face_roughness_indices` array provides O(1) access to roughness models for any face.
+
+# Coordinate System Convention
+
+The local coordinate system for each roughness model follows geographic conventions:
+
+1. **Origin**: Face center, corresponding to (0.5, 0.5) in the roughness model's UV coordinates
+2. **Z-axis**: Face normal (outward), representing "up" or elevation
+3. **Y-axis**: Points towards north (projected onto the face plane)
+4. **X-axis**: Points east (completing a right-handed coordinate system)
+
+This convention ensures that:
+- Roughness models have consistent north-aligned orientation across the surface
+- UV coordinates [0,1]×[0,1] map naturally to local coordinates with (0.5, 0.5) at origin
+- Height/elevation data in the roughness model corresponds to the local Z direction
+- Solar azimuth angles can be computed intuitively (north = 0°, east = 90°)
+
+# Example
+```julia
+# Load global shape
+global_shape = load_shape_obj("path/to/shape.obj", scale=1000)
+
+# Create hierarchical model
+hier_shape = HierarchicalShapeModel(global_shape)
+
+# Add crater roughness to specific faces
+crater = load_shape_obj("crater_roughness.obj", scale=10)
+add_roughness_model!(hier_shape, face_idx, crater, 0.01)
+```
+
+# Implementation Notes
+
+Currently, the coordinate transformations between global and local systems are computed
+on-the-fly based on face geometry. This design prioritizes memory efficiency and simplicity.
+
+## Future Considerations
+
+For performance-critical applications, consider pre-computing and storing transformation matrices:
+- Add fields: `global_to_local_rotations::Vector{SMatrix{3,3}}` and `global_to_local_translations::Vector{SVector{3}}`
+- Trade-off: ~25% increase in memory usage for O(1) transformation access
+- Benefit: Faster coordinate transformations in intensive calculations
+- Additional flexibility: Support custom orientations beyond the default north-aligned system
+
+See also: [`AbstractShapeModel`](@ref), [`ShapeModel`](@ref)
+"""
+mutable struct HierarchicalShapeModel <: AbstractShapeModel
+    global_shape           ::ShapeModel
+    face_roughness_indices ::Vector{Int}
+    roughness_models       ::Vector{ShapeModel}
+    roughness_model_scales ::Vector{Float64}
+    
+    function HierarchicalShapeModel(global_shape::ShapeModel)
+        nfaces = length(global_shape.faces)
+        face_roughness_indices = zeros(Int, nfaces)
+        return new(
+            global_shape,
+            face_roughness_indices,
+            ShapeModel[],
+            Float64[]
+        )
+    end
+end
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                      Basic Operations                             ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+"""
+    Base.show(io::IO, model::HierarchicalShapeModel)
+
+Custom display method for HierarchicalShapeModel objects.
+"""
+function Base.show(io::IO, hier_shape::HierarchicalShapeModel)
+    print(io, "Hierarchical Shape Model\n")
+    print(io, "------------------------\n")
+    print(io, "Global shape:\n")
+    print(io, "  - Nodes: $(length(hier_shape.global_shape.nodes))\n")
+    print(io, "  - Faces: $(length(hier_shape.global_shape.faces))\n")
+    print(io, "Faces with roughness: $(length(hier_shape.roughness_models)) / $(length(hier_shape.global_shape.faces))")
+end
+
+"""
+    add_roughness_model!(
+        hier_shape      ::HierarchicalShapeModel, 
+        face_idx        ::Int,
+        roughness_model ::ShapeModel,
+        scale           ::Real
+    )
+
+Add a surface roughness model to a specific face of the hierarchical shape model.
+
+# Arguments
+- `hier_shape`      : The hierarchical shape model
+- `face_idx`        : Index of the face to attach the roughness to
+- `roughness_model` : The shape model representing the surface roughness
+- `scale`           : Scale factor for the roughness model
+
+# Notes
+- The roughness model is automatically positioned at the face center
+  with a north-aligned local coordinate system (x: East, y: North, z: Up).
+- The transformation between global and local coordinates is computed
+  on-the-fly based on the face geometry.
+"""
+function add_roughness_model!(
+    hier_shape      ::HierarchicalShapeModel, 
+    face_idx        ::Int,
+    roughness_model ::ShapeModel,
+    scale           ::Real
+)
+    @assert 1 ≤ face_idx ≤ length(hier_shape.global_shape.faces) "Invalid face index"
+    @assert hier_shape.face_roughness_indices[face_idx] == 0 "Face already has a roughness model"
+    
+    # Add the roughness model and its metadata
+    push!(hier_shape.roughness_models, roughness_model)
+    push!(hier_shape.roughness_model_scales, Float64(scale))
+    
+    # Update the face-to-roughness mapping
+    roughness_idx = length(hier_shape.roughness_models)
+    hier_shape.face_roughness_indices[face_idx] = roughness_idx
+    
+    return nothing
+end
+
+"""
+    get_roughness_model(hier_shape::HierarchicalShapeModel, face_idx::Int) -> Union{Nothing, ShapeModel}
+
+Get the roughness model associated with a specific face.
+
+# Arguments
+- `hier_shape` : The hierarchical shape model
+- `face_idx`   : Index of the face to query
+
+# Returns
+- `ShapeModel` : The roughness model for the specified face
+- `nothing`    : If the face has no associated roughness model
+"""
+function get_roughness_model(hier_shape::HierarchicalShapeModel, face_idx::Int)::Union{Nothing, ShapeModel}
+    roughness_idx = hier_shape.face_roughness_indices[face_idx]
+    return roughness_idx == 0 ? nothing : hier_shape.roughness_models[roughness_idx]
+end
+
+"""
+    get_roughness_model_scale(hier_shape::HierarchicalShapeModel, face_idx::Int) -> Union{Nothing, Float64}
+
+Get the scale factor for the roughness model on a specific face.
+
+# Arguments
+- `hier_shape` : The hierarchical shape model
+- `face_idx`   : Index of the face to query
+
+# Returns
+- `Float64` : The scale factor for the roughness model
+- `nothing` : If the face has no associated roughness model
+"""
+function get_roughness_model_scale(hier_shape::HierarchicalShapeModel, face_idx::Int)::Union{Nothing, Float64}
+    roughness_idx = hier_shape.face_roughness_indices[face_idx]
+    return roughness_idx == 0 ? nothing : hier_shape.roughness_model_scales[roughness_idx]
+end
+
+"""
+    has_roughness(hier_shape::HierarchicalShapeModel, face_idx::Int) -> Bool
+
+Check if a face has an associated roughness model.
+
+# Arguments
+- `hier_shape` : The hierarchical shape model
+- `face_idx`   : Index of the face to check
+
+# Returns
+- `true`  : If the face has an associated roughness model
+- `false` : If the face has no roughness model
+"""
+function has_roughness(hier_shape::HierarchicalShapeModel, face_idx::Int)::Bool
+    return hier_shape.face_roughness_indices[face_idx] != 0
+end
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                   Coordinate Transformations                      ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+"""
+    transform_point_global_to_local(
+        hier_shape::HierarchicalShapeModel,
+        face_idx::Int,
+        point::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a point from global coordinates to local roughness model coordinates.
+
+Returns the original point if the face has no roughness model.
+"""
+function transform_point_global_to_local(
+    hier_shape::HierarchicalShapeModel, 
+    face_idx::Int,
+    point::StaticVector{3}
+)
+    roughness_idx = hier_shape.face_roughness_indices[face_idx]
+    roughness_idx == 0 && return point
+    
+    # Compute transformation on-the-fly based on face geometry
+    # TODO: Implement coordinate transformation based on face normal and geographic conventions
+    # For now, return the original point
+    return point
+end
+
+"""
+    transform_point_local_to_global(
+        hier_shape::HierarchicalShapeModel,
+        face_idx::Int,
+        point::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a point from local roughness model coordinates to global coordinates.
+
+Returns the original point if the face has no roughness model.
+"""
+function transform_point_local_to_global(
+    hier_shape::HierarchicalShapeModel,
+    face_idx::Int,
+    point::StaticVector{3}
+)
+    roughness_idx = hier_shape.face_roughness_indices[face_idx]
+    roughness_idx == 0 && return point
+    
+    # Compute transformation on-the-fly based on face geometry
+    # TODO: Implement coordinate transformation based on face normal and geographic conventions
+    # For now, return the original point
+    return point
+end
+
+"""
+    transform_vector_global_to_local(
+        hier_shape::HierarchicalShapeModel,
+        face_idx::Int,
+        vector::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a vector (direction) from global coordinates to local roughness model coordinates.
+Vectors are not affected by translation, only rotation and scaling.
+
+Returns the original vector if the face has no roughness model.
+"""
+function transform_vector_global_to_local(
+    hier_shape::HierarchicalShapeModel,
+    face_idx::Int,
+    vector::StaticVector{3}
+)
+    roughness_idx = hier_shape.face_roughness_indices[face_idx]
+    roughness_idx == 0 && return vector
+    
+    # Compute transformation on-the-fly based on face geometry
+    # TODO: Implement coordinate transformation based on face normal and geographic conventions
+    # For now, return the original vector
+    return vector
+end
+
+"""
+    transform_vector_local_to_global(
+        hier_shape::HierarchicalShapeModel,
+        face_idx::Int,
+        vector::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a vector (direction) from local roughness model coordinates to global coordinates.
+Vectors are not affected by translation, only rotation and scaling.
+
+Returns the original vector if the face has no roughness model.
+"""
+function transform_vector_local_to_global(
+    hier_shape::HierarchicalShapeModel,
+    face_idx::Int,
+    vector::StaticVector{3}
+)
+    roughness_idx = hier_shape.face_roughness_indices[face_idx]
+    roughness_idx == 0 && return vector
+    
+    # Compute transformation on-the-fly based on face geometry
+    # TODO: Implement coordinate transformation based on face normal and geographic conventions
+    # For now, return the original vector
+    return vector
+end

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -477,11 +477,17 @@ This transformation is used when adding new roughness models to face_roughness_t
 # Keyword Arguments
 - `scale`      : Scale factor for the roughness model (default: 1.0)
 
-The transformation includes:
-1. Translation to face center
-2. Rotation to local coordinate system (north-aligned)
-3. Scaling by 1/scale
-4. Offset to UV center (0.5, 0.5, 0.0)
+# Implementation Note
+This function leverages the equivalence between active and passive transformations:
+- Builds an active local-to-global transformation
+- Returns it as the passive global-to-local transformation (they are equivalent)
+- No inverse computation is needed
+
+The transformation pipeline (as active local-to-global):
+1. Offset from UV center (0.5, 0.5, 0.0) to local origin
+2. Scale from local units to global units
+3. Rotate from local coordinate system to global (north-aligned)
+4. Translate from local origin to face center
 """
 function compute_global_to_local_affine(hier_shape::HierarchicalShapeModel, face_idx::Int; scale::Float64=1.0)
     # Get local coordinate system

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -300,7 +300,7 @@ Add the same surface roughness model to all faces of the hierarchical shape mode
 # Notes
 - This function applies the roughness model to ALL faces, overwriting any existing assignments.
 - All faces will share the same ShapeModel instance, making this memory-efficient.
-- Appropriate transformations are automatically computed for each face using `compute_face_roughness_transform`.
+- Appropriate transformations are automatically computed for each face using [`compute_face_roughness_transform`](@ref).
 - Use the face-specific version `add_roughness_models!(hier_shape, roughness_model, face_idx; scale, transform)`
   to selectively apply different models to individual faces or to provide custom transformations.
 """
@@ -350,7 +350,7 @@ Add a surface roughness model to a specific face of the hierarchical shape model
 - `transform::Union{Nothing, AFFINE_MAP_TYPE}` :
         Affine transformation from global to local coordinates (optional).
         If `nothing` (default), automatically computes an appropriate transformation
-        using `compute_face_roughness_transform`
+        using [`compute_face_roughness_transform`](@ref)
 
 # Notes
 - If the face already has a roughness model, it will be replaced.

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -753,10 +753,9 @@ function transform_physical_vector_global_to_local(
     
     # Extract rotation part from the linear transformation
     # The linear part includes both rotation and scale, so we need to remove the scale
-    # Since transform.linear = rotation * scale, and scale is uniform,
-    # we can extract the rotation by normalizing
+    # Since transform.linear = rotation * scale, we divide by scale to extract pure rotation
     scale = hier_shape.face_roughness_scales[face_idx]
-    rotation = transform.linear * scale  # Remove the 1/scale factor
+    rotation = transform.linear / scale  # Extract pure rotation
     v_local = rotation * v_global        # Apply pure rotation
     
     return v_local
@@ -787,7 +786,8 @@ Use this for quantities where the physical magnitude must be preserved:
 - Magnetic fields
 - Any vector representing a physical quantity rather than a geometric displacement
 
-For geometric vectors (displacements, velocities), use `transform_geometric_vector_local_to_global` instead.
+For geometric vectors (e.g., displacements, velocities),
+use `transform_geometric_vector_local_to_global` instead.
 """
 function transform_physical_vector_local_to_global(
     hier_shape ::HierarchicalShapeModel,
@@ -800,9 +800,10 @@ function transform_physical_vector_local_to_global(
     # Get global-to-local transformation
     transform = get_roughness_model_transform(hier_shape, face_idx)
     
-    # Extract rotation part from the linear transformation, inverse it, and apply it.
+    # Extract rotation part from the linear transformation
+    # Since transform.linear = rotation * scale, we divide by scale to extract pure rotation
     scale = hier_shape.face_roughness_scales[face_idx]
-    rotation = transform.linear * scale  # Remove the 1/scale factor
+    rotation = transform.linear / scale  # Extract pure rotation
     v_global = rotation' * v_local       # Apply inverse rotation (transpose for orthogonal matrix)
     
     return v_global

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -168,15 +168,11 @@ The roughness_models array is emptied to free memory.
 """
 function clear_roughness_models!(hier_shape::HierarchicalShapeModel)
     
-    fill!(hier_shape.face_roughness_indices, 0)   # Reset all face indices to 0 (no roughness)
-    fill!(hier_shape.face_roughness_scales, 1.0)  # Reset all scales to 1.0 (identity)
+    hier_shape.face_roughness_indices .= 0                       # Reset all face indices to 0 (no roughness)
+    hier_shape.face_roughness_scales .= 1.0                      # Reset all scales to 1.0 (identity)
+    hier_shape.face_roughness_transforms .= IDENTITY_AFFINE_MAP  # Reset all transforms to identity
     
-    # Reset all transforms to identity
-    for i in eachindex(hier_shape.face_roughness_transforms)
-        hier_shape.face_roughness_transforms[i] = IDENTITY_AFFINE_MAP
-    end
-    
-    empty!(hier_shape.roughness_models)           # Clear the roughness models array
+    empty!(hier_shape.roughness_models)  # Clear the roughness models array
     
     return nothing
 end
@@ -213,11 +209,8 @@ function clear_roughness_models!(hier_shape::HierarchicalShapeModel, face_idx::I
         deleteat!(hier_shape.roughness_models, roughness_idx)
 
         # Update all face indices that point to models after the deleted one
-        for i in eachindex(hier_shape.face_roughness_indices)
-            if hier_shape.face_roughness_indices[i] > roughness_idx
-                hier_shape.face_roughness_indices[i] -= 1
-            end
-        end
+        mask = hier_shape.face_roughness_indices .> roughness_idx
+        hier_shape.face_roughness_indices[mask] .-= 1
     end
     
     return nothing
@@ -256,10 +249,8 @@ function add_roughness_models!(
     roughness_idx = length(hier_shape.roughness_models)
     
     # Apply to all faces
-    for face_idx in eachindex(hier_shape.global_shape.faces)
-        hier_shape.face_roughness_indices[face_idx] = roughness_idx
-        hier_shape.face_roughness_scales[face_idx] = Float64(scale)
-    end
+    hier_shape.face_roughness_indices .= roughness_idx
+    hier_shape.face_roughness_scales .= Float64(scale)
     
     return nothing
 end

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -386,20 +386,16 @@ function add_roughness_models!(
 )
     @assert 1 ≤ face_idx ≤ length(hier_shape.global_shape.faces) "Invalid face index"
     
-    # Check if this model already exists
-    roughness_idx = 0
-    for (idx, model) in enumerate(hier_shape.roughness_models)
-        if model === roughness_model  # Use === for object identity
-            roughness_idx = idx
-            break
+    # Find or add the roughness model
+    # `something` uses lazy evaluation: the second argument (begin...end block) is only
+    # evaluated if the first argument returns `nothing` (if no existing model found)
+    roughness_idx = something(
+        findfirst(existing_model -> existing_model === roughness_model, hier_shape.roughness_models),
+        begin
+            push!(hier_shape.roughness_models, roughness_model)
+            length(hier_shape.roughness_models)
         end
-    end
-    
-    # Add the model if it doesn't exist
-    if roughness_idx == 0
-        push!(hier_shape.roughness_models, roughness_model)
-        roughness_idx = length(hier_shape.roughness_models)
-    end
+    )
     
     # Update the face-to-roughness mapping and scale
     hier_shape.face_roughness_indices[face_idx] = roughness_idx

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -7,9 +7,10 @@ added to base shape models while maintaining computational efficiency.
 
 The hierarchical structure uses:
 - Base shape model (ShapeModel) for global geometry
-- Detail shape models (ShapeModel) for localized surface roughness
-- Transformation matrices and scales stored as arrays
+- Surface roughness models (ShapeModel) attached to global shape's faces
+- Scale factors for each roughness model
 - Efficient indexing for O(1) access to face details
+- On-the-fly computation of coordinate transformations
 
 ## Implementation Considerations
 

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -366,7 +366,7 @@ This function clears the assignment for the specified face.
 If the roughness model is no longer used by any face, it will be removed from memory.
 """
 function clear_roughness_models!(hier_shape::HierarchicalShapeModel, face_idx::Int)
-    @assert 1 ≤ face_idx ≤ length(hier_shape.global_shape.faces) "Invalid face index"
+    1 ≤ face_idx ≤ length(hier_shape.global_shape.faces) || throw(BoundsError(hier_shape.global_shape.faces, face_idx))
     
     # Get the model index before clearing
     roughness_idx = hier_shape.face_roughness_indices[face_idx]
@@ -474,7 +474,7 @@ function add_roughness_models!(
     scale           ::Float64 = 1.0,
     transform       ::Union{Nothing, AFFINE_MAP_TYPE} = nothing,
 )
-    @assert 1 ≤ face_idx ≤ length(hier_shape.global_shape.faces) "Invalid face index"
+    1 ≤ face_idx ≤ length(hier_shape.global_shape.faces) || throw(BoundsError(hier_shape.global_shape.faces, face_idx))
     scale > 0 || throw(ArgumentError("scale must be positive, got $scale"))
     
     # Find or add the roughness model
@@ -640,7 +640,7 @@ end
     transform_point_global_to_local(
         hier_shape ::HierarchicalShapeModel,
         face_idx   ::Int,
-        point      ::StaticVector{3}
+        p_global   ::StaticVector{3}
     ) -> SVector{3, Float64}
 
 Transform a point from global to local coordinates.
@@ -648,26 +648,46 @@ Transform a point from global to local coordinates.
 # Arguments
 - `hier_shape::HierarchicalShapeModel` : The hierarchical shape model
 - `face_idx::Int`                      : Index of the face (1-based)
-- `point::StaticVector{3}`             : Point in global coordinates
+- `p_global::StaticVector{3}`          : Point in global coordinates
 
 # Returns
-- `SVector{3, Float64}` : Point in local roughness model coordinates [0,1]×[0,1]×ℝ,
-                          or original point if the face has no roughness model
+- `SVector{3, Float64}` : Point in local roughness model coordinates [0,1]×[0,1]×ℝ
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If `face_idx` is out of bounds
 
 # Notes
 The local coordinate system has its origin at the face center, with:
 - X-axis pointing east
-- Y-axis pointing north  
+- Y-axis pointing north
 - Z-axis pointing up (along face normal)
 The UV coordinates [0,1]×[0,1] are centered at (0.5, 0.5).
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+# Always check before transformation
+if has_roughness_model(hier_shape, face_idx)
+    p_local = transform_point_global_to_local(hier_shape, face_idx, p_global)
+    # Process in the local coordinate system
+else
+    # Handle the face without any roughness model
+end
+```
 """
 function transform_point_global_to_local(
     hier_shape ::HierarchicalShapeModel, 
     face_idx   ::Int,
     p_global   ::StaticVector{3}
-)
-    # If no roughness model, return the original point
-    !has_roughness_model(hier_shape, face_idx) && return p_global
+)::SVector{3, Float64}
+    
+    # Check if the face has a roughness model
+    !has_roughness_model(hier_shape, face_idx) && 
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform to local coordinates."))
     
     # Get global-to-local transformation and apply it
     transform = get_roughness_model_transform(hier_shape, face_idx)
@@ -691,20 +711,41 @@ Transform a point from local to global coordinates.
 - `p_local::StaticVector{3}`           : Point in local roughness model coordinates [0,1]×[0,1]×ℝ
 
 # Returns
-- `SVector{3, Float64}` : Point in global coordinates, or original point if the face has no roughness model
+- `SVector{3, Float64}` : Point in global coordinates
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
 
 # Notes
 Inverse transformation of `transform_point_global_to_local`.
 Local coordinates are expected to be in the range [0,1]×[0,1] for UV,
 with arbitrary Z values representing elevation above the face.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+# Always check before transformation
+if has_roughness_model(hier_shape, face_idx)
+    p_global = transform_point_local_to_global(hier_shape, face_idx, p_local)
+    # Process in the global coordinate system
+else
+    # Handle the face without any roughness model
+end
+```
 """
 function transform_point_local_to_global(
     hier_shape ::HierarchicalShapeModel,
     face_idx   ::Int,
     p_local    ::StaticVector{3}
-)
-    # If no roughness model, return the original point
-    !has_roughness_model(hier_shape, face_idx) && return p_local
+)::SVector{3, Float64}
+    
+    # Check if the face has a roughness model
+    !has_roughness_model(hier_shape, face_idx) && 
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform from local coordinates."))
     
     # Get global-to-local transformation, invert it, and apply it.
     transform = get_roughness_model_transform(hier_shape, face_idx)
@@ -733,8 +774,11 @@ Transform a geometric vector from global to local coordinates.
 - `v_global::StaticVector{3}`          : Geometric vector in global coordinates
 
 # Returns
-- `SVector{3, Float64}` : Vector in local roughness model coordinates (scaled),
-                          or original vector if the face has no roughness model
+- `SVector{3, Float64}` : Vector in local roughness model coordinates (scaled)
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
 
 # Notes
 This function applies both rotation and scaling, suitable for geometric vectors
@@ -743,15 +787,32 @@ in local coordinates corresponds to the physical scale of the roughness model.
 
 For physical vectors (e.g., forces, torques) that should preserve magnitude,
 use `transform_physical_vector_global_to_local` instead.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+# Always check before transformation
+if has_roughness_model(hier_shape, face_idx)
+    v_local = transform_geometric_vector_global_to_local(hier_shape, face_idx, v_global)
+    # Process in the local coordinate system
+else
+    # Handle the face without any roughness model
+end
+```
 """
 function transform_geometric_vector_global_to_local(
     hier_shape ::HierarchicalShapeModel,
     face_idx   ::Int,
     v_global   ::StaticVector{3}
-)
-    # If no roughness model, return the original vector
-    !has_roughness_model(hier_shape, face_idx) && return v_global
-
+)::SVector{3, Float64}
+    
+    # Check if the face has a roughness model
+    !has_roughness_model(hier_shape, face_idx) && 
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform to local coordinates."))
+    
     # Get global-to-local transformation
     transform = get_roughness_model_transform(hier_shape, face_idx)
     
@@ -777,8 +838,11 @@ Transform a geometric vector from local to global coordinates.
 - `v_local::StaticVector{3}`           : Geometric vector in local roughness model coordinates
 
 # Returns
-- `SVector{3, Float64}` : Vector in global coordinates (scaled),
-                          or original vector if the face has no roughness model
+- `SVector{3, Float64}` : Vector in global coordinates (scaled)
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
 
 # Notes
 Inverse transformation of `transform_geometric_vector_global_to_local`.
@@ -787,14 +851,31 @@ such as displacements and velocities.
 
 For physical vectors (e.g., forces, torques) that should preserve magnitude,
 use `transform_physical_vector_local_to_global` instead.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+# Always check before transformation
+if has_roughness_model(hier_shape, face_idx)
+    v_global = transform_geometric_vector_local_to_global(hier_shape, face_idx, v_local)
+    # Process in the global coordinate system
+else
+    # Handle the face without any roughness model
+end
+```
 """
 function transform_geometric_vector_local_to_global(
     hier_shape ::HierarchicalShapeModel,
     face_idx   ::Int,
     v_local    ::StaticVector{3}
-)
-    # If no roughness model, return the original vector
-    !has_roughness_model(hier_shape, face_idx) && return v_local
+)::SVector{3, Float64}
+    
+    # Check if the face has a roughness model
+    !has_roughness_model(hier_shape, face_idx) && 
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform from local coordinates."))
     
     # Get global-to-local transformation
     transform = get_roughness_model_transform(hier_shape, face_idx)
@@ -826,8 +907,11 @@ Physical vectors are only rotated, not scaled, preserving their physical magnitu
 - `v_global::StaticVector{3}`          : Physical vector in global coordinates
 
 # Returns
-- `SVector{3, Float64}` : Physical vector in local coordinate frame (not scaled),
-                          or original vector if the face has no roughness model
+- `SVector{3, Float64}` : Physical vector in local coordinate frame (not scaled)
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
 
 # Note
 Use this for quantities where the physical magnitude must be preserved:
@@ -838,14 +922,31 @@ Use this for quantities where the physical magnitude must be preserved:
 
 For geometric vectors (e.g., displacements, velocities),
 use `transform_geometric_vector_global_to_local` instead.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+# Always check before transformation
+if has_roughness_model(hier_shape, face_idx)
+    v_local = transform_physical_vector_global_to_local(hier_shape, face_idx, v_global)
+    # Process in the local coordinate system
+else
+    # Handle the face without any roughness model
+end
+```
 """
 function transform_physical_vector_global_to_local(
     hier_shape ::HierarchicalShapeModel,
     face_idx   ::Int,
     v_global   ::StaticVector{3}
-)
-    # If no roughness model, return the original vector
-    !has_roughness_model(hier_shape, face_idx) && return v_global
+)::SVector{3, Float64}
+    
+    # Check if the face has a roughness model
+    !has_roughness_model(hier_shape, face_idx) && 
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform to local coordinates."))
     
     # Get global-to-local transformation
     transform = get_roughness_model_transform(hier_shape, face_idx)
@@ -876,8 +977,11 @@ Physical vectors are only rotated, not scaled, preserving their physical magnitu
 - `v_local::StaticVector{3}`           : Physical vector in local coordinates
 
 # Returns
-- `SVector{3, Float64}` : Physical vector in global coordinate frame (not scaled),
-                          or original vector if the face has no roughness model
+- `SVector{3, Float64}` : Physical vector in global coordinate frame (not scaled)
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
 
 # Note
 Use this for quantities where the physical magnitude must be preserved:
@@ -888,14 +992,31 @@ Use this for quantities where the physical magnitude must be preserved:
 
 For geometric vectors (e.g., displacements, velocities),
 use `transform_geometric_vector_local_to_global` instead.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+# Always check before transformation
+if has_roughness_model(hier_shape, face_idx)
+    v_global = transform_physical_vector_local_to_global(hier_shape, face_idx, v_local)
+    # Process in the global coordinate system
+else
+    # Handle the face without any roughness model
+end
+```
 """
 function transform_physical_vector_local_to_global(
     hier_shape ::HierarchicalShapeModel,
     face_idx   ::Int,
     v_local    ::StaticVector{3}
-)
-    # If no roughness model, return the original vector
-    !has_roughness_model(hier_shape, face_idx) && return v_local
+)::SVector{3, Float64}
+    
+    # Check if the face has a roughness model
+    !has_roughness_model(hier_shape, face_idx) && 
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform from local coordinates."))
     
     # Get global-to-local transformation
     transform = get_roughness_model_transform(hier_shape, face_idx)

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -611,11 +611,11 @@ function compute_face_roughness_transform(hier_shape::HierarchicalShapeModel, fa
     scale_transform = LinearMap(UniformScaling(scale))
     
     # 3. Rotation from local to global coordinates
-    # Columns are local basis vectors for the active transformation
+    # Columns are local basis vectors for the active transformation (column-major)
     R = SMatrix{3,3}(
-        ê_x[1], ê_y[1], ê_z[1],  # Column 1: ê_x
-        ê_x[2], ê_y[2], ê_z[2],  # Column 2: ê_y
-        ê_x[3], ê_y[3], ê_z[3]   # Column 3: ê_z
+        ê_x[1], ê_x[2], ê_x[3],  # Column 1: ê_x
+        ê_y[1], ê_y[2], ê_y[3],  # Column 2: ê_y
+        ê_z[1], ê_z[2], ê_z[3]   # Column 3: ê_z
     )
     rotate_to_global = LinearMap(R)
     

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -947,11 +947,11 @@ function transform_physical_vector_global_to_local(
     # Get global-to-local transformation
     transform = get_roughness_model_transform(hier_shape, face_idx)
     
-    # Extract rotation part from the linear transformation
-    # The linear part includes both rotation and scale, so we need to remove the scale
-    # Since transform.linear = rotation * scale, we divide by scale to extract pure rotation
+    # Extract pure rotation from the linear transformation.
+    # Since `transform.linear = (1/scale) * R'` (global→local),
+    # multiply by `scale` to recover `R'` for rotation-only mapping.
     scale = hier_shape.face_roughness_scales[face_idx]
-    rotation = transform.linear / scale  # Extract pure rotation
+    rotation = transform.linear * scale  # Extract pure rotation (R')
     v_local = rotation * v_global        # Apply pure rotation
     
     return v_local
@@ -1017,11 +1017,11 @@ function transform_physical_vector_local_to_global(
     # Get global-to-local transformation
     transform = get_roughness_model_transform(hier_shape, face_idx)
     
-    # Extract rotation part from the linear transformation
-    # Since transform.linear = rotation * scale, we divide by scale to extract pure rotation
+    # Extract pure rotation from the linear transformation.
+    # With `transform.linear = (1/scale) * R'`, recover `R'` via multiplication by `scale`.
     scale = hier_shape.face_roughness_scales[face_idx]
-    rotation = transform.linear / scale  # Extract pure rotation
-    v_global = rotation' * v_local       # Apply inverse rotation (transpose for orthogonal matrix)
+    rotation = transform.linear * scale  # Extract pure rotation (R')
+    v_global = rotation' * v_local       # Apply inverse rotation (R)
     
     return v_global
 end

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -586,10 +586,9 @@ is intended to be stored in the `hier_shape.face_roughness_transforms` field.
 - `AFFINE_MAP_TYPE` : The affine transformation from global to local coordinates
 
 # Implementation Note
-This function leverages the equivalence between active and passive transformations:
-- Builds an active local-to-global transformation
-- Returns it as the passive global-to-local transformation (they are equivalent)
-- No inverse computation is needed
+This function constructs the desired passive global→local transformation:
+- First, build the active local→global transform
+- Then, take its inverse to obtain the passive global→local transform
 
 The transformation pipeline (as active local-to-global):
 - 1. Offset from UV center (0.5, 0.5, 0.0) to local origin
@@ -601,8 +600,9 @@ function compute_face_roughness_transform(hier_shape::HierarchicalShapeModel, fa
     # Get local coordinate system
     origin, ê_x, ê_y, ê_z = compute_local_coordinate_system(hier_shape, face_idx)
     
-    # Build "active local-to-global" transformation using CoordinateTransformations.jl,
-    # which is equivalent to "passive global-to-local" transformation to be returned.
+    # Build the active local→global transformation using CoordinateTransformations.jl.
+    # The desired passive global→local transformation is obtained by inverting this
+    # active transform (see below).
     
     # 1. Offset from UV center to local origin
     offset_from_uv_center = Translation(-LOCAL_CENTER_OFFSET)
@@ -622,7 +622,7 @@ function compute_face_roughness_transform(hier_shape::HierarchicalShapeModel, fa
     # 4. Translation from local origin to face center
     translate_to_face_center = Translation(origin)
     
-    # Compose "active local-to-global" transformation (applied right to left)
+    # Compose active local→global transformation (applied right to left)
     active_local_to_global = translate_to_face_center ∘ rotate_to_global ∘ scale_transform ∘ offset_from_uv_center
 
     # We need a passive global→local transformation.

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -625,9 +625,9 @@ function compute_face_roughness_transform(hier_shape::HierarchicalShapeModel, fa
     # Compose "active local-to-global" transformation (applied right to left)
     active_local_to_global = translate_to_face_center ∘ rotate_to_global ∘ scale_transform ∘ offset_from_uv_center
 
-    # "active local-to-global" transformation is equivalent to "passive global-to-local" transformation
-    # (No inverse needed due to active/passive equivalence)
-    passive_global_to_local = active_local_to_global
+    # We need a passive global→local transformation.
+    # This is obtained by inverting the active local→global transformation.
+    passive_global_to_local = inv(active_local_to_global)
     
     return passive_global_to_local
 end

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -125,6 +125,52 @@ mutable struct HierarchicalShapeModel <: AbstractShapeModel
     end
 end
 
+"""
+    HierarchicalShapeModel(
+        nodes::Vector{<:StaticVector{3}}, faces::Vector{<:StaticVector{3}};
+        with_face_visibility=false, with_bvh=false,
+    ) -> HierarchicalShapeModel
+
+Construct a `HierarchicalShapeModel` from nodes and faces, automatically computing face properties.
+This constructor creates a `HierarchicalShapeModel` with an empty roughness model collection.
+
+# Arguments
+- `nodes` : Vector of vertex positions
+- `faces` : Vector of triangular face definitions (vertex indices)
+
+# Keyword Arguments
+- `with_face_visibility::Bool=false` : Whether to compute `face_visibility_graph` and `face_max_elevations`
+- `with_bvh::Bool=false`             : Whether to build BVH for accelerated ray tracing
+
+# Returns
+- `HierarchicalShapeModel`: Hierarchical shape model with computed face properties and empty roughness models
+
+# Examples
+```julia
+# Create a simple hierarchical model
+nodes = [SA[0,0,0], SA[1,0,0], SA[0,1,0], SA[0,0,1]]
+faces = [SA[1,2,3], SA[1,2,4], SA[1,3,4], SA[2,3,4]]
+hier_shape = HierarchicalShapeModel(nodes, faces)
+
+# Create with visibility computation
+hier_shape = HierarchicalShapeModel(nodes, faces, with_face_visibility=true)
+
+# Add roughness models later for all faces of the global shape
+roughness_model = ShapeModel(roughness_nodes, roughness_faces)
+add_roughness_models!(hier_shape, roughness_model; scale=0.01)
+```
+"""
+function HierarchicalShapeModel(
+    nodes::Vector{<:StaticVector{3}}, faces::Vector{<:StaticVector{3}};
+    with_face_visibility=false, with_bvh=false,
+)
+    # Create the base ShapeModel
+    global_shape = ShapeModel(nodes, faces; with_face_visibility, with_bvh)
+    
+    # Create HierarchicalShapeModel from the base shape
+    return HierarchicalShapeModel(global_shape)
+end
+
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║                      Display Functions                            ║
 # ╚═══════════════════════════════════════════════════════════════════╝
@@ -146,6 +192,68 @@ function Base.show(io::IO, hier_shape::HierarchicalShapeModel)
     print(io, "Faces with roughness    : $(nfaces_with_roughness)\n")
     print(io, "Unique roughness models : $(length(hier_shape.roughness_models))")
 end
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                        Method Forwarding                          ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+# Forward methods to the global_shape for compatibility with ShapeModel interface
+# These methods delegate to the global shape model, ignoring local roughness
+
+#### From `shape_operations.jl` ####
+
+# Shape metric functions
+polyhedron_volume(hier_shape::HierarchicalShapeModel) = polyhedron_volume(hier_shape.global_shape)
+equivalent_radius(hier_shape::HierarchicalShapeModel) = equivalent_radius(hier_shape.global_shape)
+maximum_radius(hier_shape::HierarchicalShapeModel) = maximum_radius(hier_shape.global_shape)
+minimum_radius(hier_shape::HierarchicalShapeModel) = minimum_radius(hier_shape.global_shape)
+
+# Face properties
+get_face_nodes(hier_shape::HierarchicalShapeModel, face_idx::Int) = get_face_nodes(hier_shape.global_shape, face_idx)
+
+#### From `ray_intersection.jl` ####
+
+# Ray-triangle intersection (single face)
+intersect_ray_triangle(ray::Ray, hier_shape::HierarchicalShapeModel, face_idx::Integer) =
+    intersect_ray_triangle(ray, hier_shape.global_shape, face_idx)
+
+# Ray-shape intersection (rays' origins and directions as matrices)
+intersect_ray_shape(hier_shape::HierarchicalShapeModel, origins::AbstractMatrix{<:Real}, directions::AbstractMatrix{<:Real}) = 
+    intersect_ray_shape(hier_shape.global_shape, origins, directions)
+
+# Ray-shape intersection (single ray)
+intersect_ray_shape(ray::Ray, hier_shape::HierarchicalShapeModel) = intersect_ray_shape(ray, hier_shape.global_shape)
+
+# Ray-shape intersection (vector of rays)
+intersect_ray_shape(rays::AbstractVector{Ray}, hier_shape::HierarchicalShapeModel) = intersect_ray_shape(rays, hier_shape.global_shape)
+
+# Ray-shape intersection (matrix of rays)
+intersect_ray_shape(rays::AbstractMatrix{Ray}, hier_shape::HierarchicalShapeModel) = intersect_ray_shape(rays, hier_shape.global_shape)
+
+#### From `illumination.jl` ####
+
+# Illumination check for a single face
+isilluminated(hier_shape::HierarchicalShapeModel, r☉::StaticVector{3}, face_idx::Integer; with_self_shadowing::Bool) =
+    isilluminated(hier_shape.global_shape, r☉, face_idx; with_self_shadowing)
+
+# Batch illumination update
+update_illumination!(illuminated_faces::AbstractVector{Bool}, hier_shape::HierarchicalShapeModel, r☉::StaticVector{3}; with_self_shadowing::Bool) =
+    update_illumination!(illuminated_faces, hier_shape.global_shape, r☉; with_self_shadowing)
+
+#### From `face_visibility_graph.jl` ####
+
+# Face visibility graph
+build_face_visibility_graph!(hier_shape::HierarchicalShapeModel) = build_face_visibility_graph!(hier_shape.global_shape)
+
+#### From `face_max_elevations.jl` ####
+
+# Face max elevations
+compute_face_max_elevations!(hier_shape::HierarchicalShapeModel) = compute_face_max_elevations!(hier_shape.global_shape)
+
+#### From `shape_model.jl` ####
+
+# BVH construction
+build_bvh!(hier_shape::HierarchicalShapeModel) = build_bvh!(hier_shape.global_shape)
 
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║                   Roughness Model Accessors                       ║
@@ -309,6 +417,8 @@ function add_roughness_models!(
     roughness_model ::ShapeModel;
     scale           ::Float64 = 1.0,
 )
+    scale > 0 || throw(ArgumentError("scale must be positive, got $scale"))
+    
     # Clear all existing roughness models first
     clear_roughness_models!(hier_shape)
     
@@ -365,6 +475,7 @@ function add_roughness_models!(
     transform       ::Union{Nothing, AFFINE_MAP_TYPE} = nothing,
 )
     @assert 1 ≤ face_idx ≤ length(hier_shape.global_shape.faces) "Invalid face index"
+    scale > 0 || throw(ArgumentError("scale must be positive, got $scale"))
     
     # Find or add the roughness model
     # `something` uses lazy evaluation: the second argument (begin...end block) is only

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -235,9 +235,9 @@ The roughness_models array is emptied to free memory.
 """
 function clear_roughness_models!(hier_shape::HierarchicalShapeModel)
     
-    hier_shape.face_roughness_indices .= 0                       # Reset all face indices to 0 (no roughness)
-    hier_shape.face_roughness_scales .= 1.0                      # Reset all scales to 1.0 (identity)
-    hier_shape.face_roughness_transforms .= IDENTITY_AFFINE_MAP  # Reset all transforms to identity
+    hier_shape.face_roughness_indices    .= 0                         # Reset all face indices to 0 (no roughness)
+    hier_shape.face_roughness_scales     .= 1.0                       # Reset all scales to 1.0 (identity)
+    hier_shape.face_roughness_transforms .= Ref(IDENTITY_AFFINE_MAP)  # Reset all transforms to identity
     
     empty!(hier_shape.roughness_models)  # Clear the roughness models array
     
@@ -264,8 +264,8 @@ function clear_roughness_models!(hier_shape::HierarchicalShapeModel, face_idx::I
     roughness_idx = hier_shape.face_roughness_indices[face_idx]
     
     # Clear the face's roughness assignment
-    hier_shape.face_roughness_indices[face_idx] = 0                       # Reset to no roughness
-    hier_shape.face_roughness_scales[face_idx] = 1.0                      # Reset to identity scale
+    hier_shape.face_roughness_indices[face_idx]    = 0                    # Reset to no roughness
+    hier_shape.face_roughness_scales[face_idx]     = 1.0                  # Reset to identity scale
     hier_shape.face_roughness_transforms[face_idx] = IDENTITY_AFFINE_MAP  # Reset transform to identity
     
     # Check if this model is still used by other faces

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -586,23 +586,20 @@ is intended to be stored in the `hier_shape.face_roughness_transforms` field.
 - `AFFINE_MAP_TYPE` : The affine transformation from global to local coordinates
 
 # Implementation Note
-This function constructs the desired passive global→local transformation:
-- First, build the active local→global transform
-- Then, take its inverse to obtain the passive global→local transform
+This function constructs the desired passive global→local transformation
+via an intermediate active local→global transformation:
 
-The transformation pipeline (as active local-to-global):
+The transformation pipeline:
 - 1. Offset from UV center (0.5, 0.5, 0.0) to local origin
 - 2. Scale from local units to global units
 - 3. Rotate from local coordinate system to global (north-aligned)
 - 4. Translate from local origin to face center
+- 5. Compose active local→global transformation
+- 6. Invert the above to obtain passive global→local transformation
 """
 function compute_face_roughness_transform(hier_shape::HierarchicalShapeModel, face_idx::Int; scale::Float64=1.0)
     # Get local coordinate system
     origin, ê_x, ê_y, ê_z = compute_local_coordinate_system(hier_shape, face_idx)
-    
-    # Build the active local→global transformation using CoordinateTransformations.jl.
-    # The desired passive global→local transformation is obtained by inverting this
-    # active transform (see below).
     
     # 1. Offset from UV center to local origin
     offset_from_uv_center = Translation(-LOCAL_CENTER_OFFSET)
@@ -621,12 +618,11 @@ function compute_face_roughness_transform(hier_shape::HierarchicalShapeModel, fa
     
     # 4. Translation from local origin to face center
     translate_to_face_center = Translation(origin)
-    
-    # Compose active local→global transformation (applied right to left)
+
+    # 5. Compose active local→global transformation (applied right to left)
     active_local_to_global = translate_to_face_center ∘ rotate_to_global ∘ scale_transform ∘ offset_from_uv_center
 
-    # We need a passive global→local transformation.
-    # This is obtained by inverting the active local→global transformation.
+    # 6. Invert this to get passive global→local transformation
     passive_global_to_local = inv(active_local_to_global)
     
     return passive_global_to_local

--- a/src/shape_model.jl
+++ b/src/shape_model.jl
@@ -1,22 +1,45 @@
 #=
     shape_model.jl
 
-Defines the core `ShapeModel` type for representing polyhedral asteroid shapes.
-This type encapsulates:
+Defines the core shape model types for representing asteroid shapes.
+
+Type hierarchy:
+- `AbstractShapeModel` : Abstract base type for all shape models
+    - `ShapeModel`             : Concrete type for polyhedral shapes (triangular mesh)
+    - `HierarchicalShapeModel` : Concrete type for multi-scale shape with surface roughness models (defined in hierarchical_shape_model.jl)
+
+The ShapeModel encapsulates:
 - Vertex positions (nodes)
 - Face connectivity (triangular faces)
 - Precomputed geometric properties (centers, normals, areas)
-- Optional face-to-face visibility graph for thermal and radiative calculations
+- (Optional) Face-to-face visibility graph for thermophysical simulations
+- (Optional) Maximum elevation angles of surrounding terrain for each face
+- (Optional) Bounding volume hierarchy (BVH) for accelerated ray tracing
 =#
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                      Abstract Type Definition                     ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+"""
+    AbstractShapeModel
+
+Abstract base type for all shape models in AsteroidShapeModels.jl.
+
+Concrete subtypes include:
+- `ShapeModel`             : Standard polyhedral shape model using triangular mesh representation
+- `HierarchicalShapeModel` : Multi-scale shape model with localized surface roughness models
+"""
+abstract type AbstractShapeModel end
 
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║                        Type Definition                            ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 """
-    ShapeModel
+    ShapeModel <: AbstractShapeModel
 
-A polyhedral shape model of an asteroid.
+A polyhedral shape model of an asteroid using triangular mesh representation.
 
 # Fields
 - `nodes`                 : Vector of node positions
@@ -27,8 +50,10 @@ A polyhedral shape model of an asteroid.
 - `face_visibility_graph` : `FaceVisibilityGraph` for efficient visibility queries
 - `face_max_elevations`   : Maximum elevation angle of the surrounding terrain from each face [rad]
 - `bvh`                   : Bounding Volume Hierarchy for accelerated ray tracing
+
+See also: [`AbstractShapeModel`](@ref), [`HierarchicalShapeModel`](@ref)
 """
-mutable struct ShapeModel
+mutable struct ShapeModel <: AbstractShapeModel
     nodes        ::Vector{SVector{3, Float64}}
     faces        ::Vector{SVector{3, Int}}
 

--- a/src/shape_operations.jl
+++ b/src/shape_operations.jl
@@ -6,13 +6,13 @@ loading shape models from various sources, computing geometric properties
 such as volume and radii, and converting between different representations.
 
 Exported Functions:
-- `load_shape_obj`: Load a shape model from an OBJ file
-- `load_shape_grid`: Convert a regular grid to a shape model
-- `grid_to_faces`: Convert grid data to triangular faces
-- `polyhedron_volume`: Calculate the volume of a polyhedron
-- `equivalent_radius`: Calculate the radius of an equivalent sphere
-- `maximum_radius`: Find the maximum distance from origin
-- `minimum_radius`: Find the minimum distance from origin
+- `load_shape_obj`    : Load a shape model from an OBJ file
+- `load_shape_grid`   : Convert a regular grid to a shape model
+- `grid_to_faces`     : Convert grid data to triangular faces
+- `polyhedron_volume` : Calculate the volume of a polyhedron
+- `equivalent_radius` : Calculate the radius of an equivalent sphere
+- `maximum_radius`    : Find the maximum distance from origin
+- `minimum_radius`    : Find the minimum distance from origin
 =#
 
 # ╔═══════════════════════════════════════════════════════════════════╗
@@ -20,7 +20,12 @@ Exported Functions:
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 """
-    load_shape_obj(shapepath; scale=1.0, with_face_visibility=false, with_bvh=false) -> ShapeModel
+    load_shape_obj(shapepath;
+        scale = 1.0,
+        with_face_visibility = false,
+        with_bvh = false,
+        as_hierarchical = false,
+    ) -> Union{ShapeModel, HierarchicalShapeModel}
 
 Load a shape model from a Wavefront OBJ file.
 
@@ -31,27 +36,42 @@ Load a shape model from a Wavefront OBJ file.
 - `scale::Real=1.0`                  : Scale factor for node coordinates (e.g., 1000 to convert km to m)
 - `with_face_visibility::Bool=false` : Whether to build face-to-face visibility graph for illumination and thermophysical modeling
 - `with_bvh::Bool=false`             : Whether to build BVH for ray tracing (required for `intersect_ray_shape` and `apply_eclipse_shadowing!`)
+- `as_hierarchical::Bool=false`      : Whether to return a `HierarchicalShapeModel` instead of a `ShapeModel`
 
 # Returns
-- `ShapeModel`: Loaded shape model with computed geometric properties
+- `ShapeModel` or `HierarchicalShapeModel`: Loaded shape model with computed geometric properties
 
 # Examples
 ```julia
 # Load a shape model
-shape = load_shape_obj("asteroid.obj")
+shape = load_shape_obj("path/to/shape.obj")
 
 # Load with scaling and visibility computation
-shape = load_shape_obj("asteroid_km.obj"; scale=1000, with_face_visibility=true)
+shape = load_shape_obj("path/to/shape_km.obj"; scale=1000)
 
-# Load with all features for comprehensive analysis
-shape = load_shape_obj("asteroid.obj"; scale=1000, with_face_visibility=true, with_bvh=true)
+# Load with face visibility graph and BVH construction
+shape = load_shape_obj("path/to/shape_km.obj"; scale=1000, with_face_visibility=true, with_bvh=true)
+
+# Load as hierarchical shape model for surface roughness modeling
+hier_shape = load_shape_obj("path/to/shape_km.obj"; scale=1000, with_face_visibility=true, with_bvh=true, as_hierarchical=true)
 ```
 
-See also: [`load_shape_grid`](@ref), [`load_obj`](@ref)
+See also: [`load_shape_grid`](@ref), [`load_obj`](@ref), [`HierarchicalShapeModel`](@ref)
 """
-function load_shape_obj(shapepath; scale=1.0, with_face_visibility=false, with_bvh=false)
+function load_shape_obj(shapepath;
+    scale = 1.0,
+    with_face_visibility = false,
+    with_bvh = false,
+    as_hierarchical = false,
+)::Union{ShapeModel, HierarchicalShapeModel}
+    
     nodes, faces = load_obj(shapepath; scale)
-    return ShapeModel(nodes, faces; with_face_visibility, with_bvh)
+    
+    if as_hierarchical
+        return HierarchicalShapeModel(nodes, faces; with_face_visibility, with_bvh)
+    else
+        return ShapeModel(nodes, faces; with_face_visibility, with_bvh)
+    end
 end
 
 # ╔═══════════════════════════════════════════════════════════════════╗
@@ -118,7 +138,12 @@ function grid_to_faces(xs::AbstractVector, ys::AbstractVector, zs::AbstractMatri
 end
 
 """
-    load_shape_grid(xs, ys, zs; scale=1.0, with_face_visibility=false, with_bvh=false) -> ShapeModel
+    load_shape_grid(xs, ys, zs;
+        scale = 1.0,
+        with_face_visibility = false,
+        with_bvh = false,
+        as_hierarchical = false,
+    ) -> Union{ShapeModel, HierarchicalShapeModel}
 
 Convert a regular grid (x, y) with z-values to a shape model.
 
@@ -131,9 +156,10 @@ Convert a regular grid (x, y) with z-values to a shape model.
 - `scale::Real=1.0`                  : Scale factor to apply to all coordinates
 - `with_face_visibility::Bool=false` : Whether to build face-to-face visibility graph for illumination and thermophysical modeling
 - `with_bvh::Bool=false`             : Whether to build BVH for ray tracing (required for `intersect_ray_shape` and `apply_eclipse_shadowing!`)
+- `as_hierarchical::Bool=false`      : Whether to return a `HierarchicalShapeModel` instead of a `ShapeModel`
 
 # Returns
-- `ShapeModel`: Shape model with computed geometric properties
+- `ShapeModel` or `HierarchicalShapeModel`: Shape model with computed geometric properties
 
 # Examples
 ```julia
@@ -144,19 +170,32 @@ zs = [exp(-(x^2 + y^2)/10) for x in xs, y in ys]  # Gaussian surface
 shape = load_shape_grid(xs, ys, zs)
 
 # With scaling and visibility
-shape = load_shape_grid(xs, ys, zs, scale=1000, with_face_visibility=true)
+shape = load_shape_grid(xs, ys, zs; scale=1000, with_face_visibility=true)
 
 # With BVH acceleration (experimental)
 shape = load_shape_grid(xs, ys, zs; with_bvh=true)
+
+# As hierarchical shape model
+hier_shape = load_shape_grid(xs, ys, zs; scale=1000, as_hierarchical=true)
 ```
 
 See also: [`load_shape_obj`](@ref), [`grid_to_faces`](@ref)
 """
-function load_shape_grid(xs::AbstractVector, ys::AbstractVector, zs::AbstractMatrix; scale=1.0, with_face_visibility=false, with_bvh=false)
+function load_shape_grid(xs::AbstractVector, ys::AbstractVector, zs::AbstractMatrix;
+    scale = 1.0,
+    with_face_visibility = false,
+    with_bvh = false,
+    as_hierarchical = false,
+)::Union{ShapeModel, HierarchicalShapeModel}
+    
     nodes, faces = grid_to_faces(xs, ys, zs)
     nodes .*= scale
     
-    return ShapeModel(nodes, faces; with_face_visibility, with_bvh)
+    if as_hierarchical
+        return HierarchicalShapeModel(nodes, faces; with_face_visibility, with_bvh)
+    else
+        return ShapeModel(nodes, faces; with_face_visibility, with_bvh)
+    end
 end
 
 # ╔═══════════════════════════════════════════════════════════════════╗

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,4 +66,7 @@ include("test_helpers.jl")
     
     # Face max elevations optimization tests
     include("test_face_max_elevations.jl")
+    
+    # Hierarchical shape model tests
+    include("test_hierarchical_shape_model.jl")
 end

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -10,6 +10,18 @@ managing temporary files, and performing common assertions.
 # ║                      Common Shape Generators                      ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
+# TODO:
+# - Ensure that generated test shapes (e.g., regular tetrahedron, unit cube)
+#   produce outward-facing face normals consistently. Depending on vertex
+#   ordering, some faces may end up with inward-facing normals, which can make
+#   assumptions in tests (such as "local z ≈ +1" after transforming the global
+#   face normal) fragile.
+# - Consider either (1) adjusting vertex orderings here to enforce outward
+#   orientation for all faces, or (2) adding a small preprocessing utility that
+#   orients faces outward based on a reference point (e.g., shape centroid).
+# - Optionally add a validation helper to check orientation (e.g., centroid·normal
+#   has the expected sign) and use it in tests for clarity.
+
 """
     create_xy_triangle() -> (nodes, faces)
 

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -194,11 +194,11 @@ Tests cover:
         cube_nodes, cube_faces = create_unit_cube()
         base_shape = ShapeModel(cube_nodes, cube_faces)
         hier_shape = HierarchicalShapeModel(base_shape)
-
+        
         @testset "Coordinate system properties" begin
-            for face_idx in 1:size(cube_faces, 2)
+            for face_idx in eachindex(cube_faces)
                 origin, e_x, e_y, e_z = AsteroidShapeModels.compute_local_coordinate_system(hier_shape, face_idx)
-
+                
                 # Origin should be at face center
                 @test origin ≈ base_shape.face_centers[face_idx]
                 
@@ -212,7 +212,7 @@ Tests cover:
                 
                 # e_z should align with face normal
                 @test e_z ≈ base_shape.face_normals[face_idx]
-
+                
                 # Right-handed system
                 @test cross(e_x, e_y) ≈ e_z
             end

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -121,22 +121,32 @@ Tests cover:
         @testset "Point transformations" begin
             # Test point at face center
             face_center_global = hier_shape.global_shape.face_centers[1]
-            local_point = transform_point_global_to_local(hier_shape, 1, face_center_global)
+            face_center_local = transform_point_global_to_local(hier_shape, 1, face_center_global)
             
             # Face center should map to (0.5, 0.5, 0.0) in local coordinates
-            @test local_point[1] ≈ 0.5 atol=1e-10
-            @test local_point[2] ≈ 0.5 atol=1e-10
-            @test local_point[3] ≈ 0.0 atol=1e-10
+            @test face_center_local[1] ≈ 0.5 atol=1e-10
+            @test face_center_local[2] ≈ 0.5 atol=1e-10
+            @test face_center_local[3] ≈ 0.0 atol=1e-10
             
-            # Test round-trip transformation
-            global_point_back = transform_point_local_to_global(hier_shape, 1, local_point)
-            @test global_point_back ≈ face_center_global
+            # Test round-trip transformation of face-1's center
+            @test transform_point_local_to_global(hier_shape, 1, face_center_local) ≈ face_center_global
             
-            # Test arbitrary point
-            test_point = SVector(0.2, 0.3, 0.4)
-            local_test = transform_point_global_to_local(hier_shape, 1, test_point)
-            global_test = transform_point_local_to_global(hier_shape, 1, local_test)
-            @test global_test ≈ test_point
+            # Test round-trip transformation of arbitrary point
+            p_global = SVector(0.2, 0.3, 0.4)
+            p_local = transform_point_global_to_local(hier_shape, 1, p_global)
+            @test transform_point_local_to_global(hier_shape, 1, p_local) ≈ p_global
+
+            # Test point slightly offset along face normal
+            face_center_global = hier_shape.global_shape.face_centers[1]
+            face_normal_global = hier_shape.global_shape.face_normals[1]
+            offset = 0.1
+            p_global = face_center_global + offset * face_normal_global
+            p_local = transform_point_global_to_local(hier_shape, 1, p_global)
+            # x,y stay at UV center; z reflects elevation scaled by 1/scale
+            scale = get_roughness_model_scale(hier_shape, 1)
+            @test p_local[1] ≈ 0.5 atol=1e-10
+            @test p_local[2] ≈ 0.5 atol=1e-10
+            @test p_local[3] ≈ (offset / scale) atol=1e-10
         end
         
         @testset "Geometric vector transformations" begin

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -173,10 +173,13 @@ Tests cover:
         end
         
         @testset "Transformations without roughness model" begin
-            # Test face without roughness model
+            # Test face without roughness model - should throw ArgumentError
             @test_throws ArgumentError transform_point_global_to_local(hier_shape, 4, SVector(0.0, 0.0, 0.0))
             @test_throws ArgumentError transform_geometric_vector_global_to_local(hier_shape, 4, SVector(1.0, 0.0, 0.0))
             @test_throws ArgumentError transform_physical_vector_global_to_local(hier_shape, 4, SVector(1.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_point_local_to_global(hier_shape, 4, SVector(0.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_geometric_vector_local_to_global(hier_shape, 4, SVector(1.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_physical_vector_local_to_global(hier_shape, 4, SVector(1.0, 0.0, 0.0))
         end
     end
     
@@ -254,18 +257,20 @@ Tests cover:
     end
     
     @testset "Integration with ShapeModel interface" begin
-        hier_shape = HierarchicalShapeModel(base_shape)
+        # Create base shape with BVH for ray intersection tests
+        base_shape_with_bvh = ShapeModel(tetra_nodes, tetra_faces, with_bvh=true)
+        hier_shape = HierarchicalShapeModel(base_shape_with_bvh)
         
         # Test that HierarchicalShapeModel works with existing functions
-        @test equivalent_radius(hier_shape) ≈ equivalent_radius(base_shape)
-        @test maximum_radius(hier_shape) ≈ maximum_radius(base_shape)
-        @test minimum_radius(hier_shape) ≈ minimum_radius(base_shape)
-        @test polyhedron_volume(hier_shape) ≈ polyhedron_volume(base_shape)
+        @test equivalent_radius(hier_shape) ≈ equivalent_radius(base_shape_with_bvh)
+        @test maximum_radius(hier_shape) ≈ maximum_radius(base_shape_with_bvh)
+        @test minimum_radius(hier_shape) ≈ minimum_radius(base_shape_with_bvh)
+        @test polyhedron_volume(hier_shape) ≈ polyhedron_volume(base_shape_with_bvh)
         
         # Test ray intersection
         ray = Ray(SVector(2.0, 0.0, 0.0), SVector(-1.0, 0.0, 0.0))
         result_hier = intersect_ray_shape(ray, hier_shape)
-        result_base = intersect_ray_shape(ray, base_shape)
+        result_base = intersect_ray_shape(ray, base_shape_with_bvh)
         @test result_hier.hit == result_base.hit
         if result_hier.hit
             @test result_hier.distance ≈ result_base.distance

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -134,7 +134,7 @@ Tests cover:
             p_global = SVector(0.2, 0.3, 0.4)
             p_local = transform_point_global_to_local(hier_shape, 1, p_global)
             @test transform_point_local_to_global(hier_shape, 1, p_local) ≈ p_global
-
+            
             # Test point slightly offset along face normal
             face_center_global = hier_shape.global_shape.face_centers[1]
             face_normal_global = hier_shape.global_shape.face_normals[1]
@@ -170,7 +170,7 @@ Tests cover:
             # Test with arbitrary physical vector
             v_global = SVector(1.0, 2.0, 3.0)
             v_local = transform_physical_vector_global_to_local(hier_shape, 1, v_global)
-
+            
             # Physical vectors should not scaled with the roughness scale
             @test norm(v_local) ≈ norm(v_global)
             
@@ -220,10 +220,10 @@ Tests cover:
         
         @testset "North alignment for horizontal faces" begin
             # Find faces that are roughly horizontal (normal pointing up or down)
-            for face_idx in 1:size(cube_faces, 2)
-                normal = cube_shape.face_normals[face_idx]
-                if abs(normal[3]) > 0.9  # Nearly horizontal
-                    origin, e_x, e_y, e_z = AsteroidShapeModels.compute_local_coordinate_system(hier_cube, face_idx)
+            for face_idx in eachindex(cube_faces)
+                n̂ = base_shape.face_normals[face_idx]
+                if abs(n̂[3]) > 0.9  # Nearly horizontal
+                    origin, e_x, e_y, e_z = AsteroidShapeModels.compute_local_coordinate_system(hier_shape, face_idx)
                     
                     # e_x should point north (positive y direction in global frame)
                     @test e_x[2] > 0.9

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -124,9 +124,7 @@ Tests cover:
             face_center_local = transform_point_global_to_local(hier_shape, 1, face_center_global)
             
             # Face center should map to (0.5, 0.5, 0.0) in local coordinates
-            @test face_center_local[1] ≈ 0.5 atol=1e-10
-            @test face_center_local[2] ≈ 0.5 atol=1e-10
-            @test face_center_local[3] ≈ 0.0 atol=1e-10
+            @test face_center_local ≈ [0.5, 0.5, 0.0]
             
             # Test round-trip transformation of face-1's center
             @test transform_point_local_to_global(hier_shape, 1, face_center_local) ≈ face_center_global
@@ -144,9 +142,7 @@ Tests cover:
             p_local = transform_point_global_to_local(hier_shape, 1, p_global)
             # x,y stay at UV center; z reflects elevation scaled by 1/scale
             scale = get_roughness_model_scale(hier_shape, 1)
-            @test p_local[1] ≈ 0.5 atol=1e-10
-            @test p_local[2] ≈ 0.5 atol=1e-10
-            @test p_local[3] ≈ (offset / scale) atol=1e-10
+            @test p_local ≈ [0.5, 0.5, offset / scale]
         end
         
         @testset "Geometric vector transformations" begin

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -1,0 +1,276 @@
+#=
+    test_hierarchical_shape_model.jl
+
+Unit tests for HierarchicalShapeModel and its associated functions.
+Tests cover:
+- Type construction and initialization
+- Roughness model management
+- Coordinate transformations
+- Local coordinate system computation
+=#
+
+@testset "HierarchicalShapeModel" begin
+    msg = """\n
+    ╔═══════════════════════════════════════════════════════════════════╗
+    ║                   Test: HierarchicalShapeModel                    ║
+    ╚═══════════════════════════════════════════════════════════════════╝
+    """
+    println(msg)
+    
+    # Use helper function to create test shapes
+    tetra_nodes, tetra_faces = create_regular_tetrahedron()
+    base_shape = ShapeModel(tetra_nodes, tetra_faces)
+    
+    @testset "Construction and Basic Properties" begin
+        # Test basic construction
+        hier_shape = HierarchicalShapeModel(base_shape)
+        
+        @test hier_shape isa HierarchicalShapeModel
+        @test hier_shape isa AbstractShapeModel
+        @test hier_shape.global_shape === base_shape
+        @test length(hier_shape.face_roughness_indices) == 4
+        @test length(hier_shape.face_roughness_scales) == 4
+        @test length(hier_shape.face_roughness_transforms) == 4
+        @test length(hier_shape.roughness_models) == 0
+        
+        # All indices should be 0 initially (no roughness)
+        @test all(==(0), hier_shape.face_roughness_indices)
+        @test all(==(1.0), hier_shape.face_roughness_scales)
+        @test all(==(AsteroidShapeModels.IDENTITY_AFFINE_MAP), hier_shape.face_roughness_transforms)
+        
+        # Test property access through global_shape
+        @test hier_shape.global_shape.face_centers[1] == base_shape.face_centers[1]
+        @test hier_shape.global_shape.face_normals[1] == base_shape.face_normals[1]
+        @test hier_shape.global_shape.face_areas[1] == base_shape.face_areas[1]
+    end
+    
+    @testset "Roughness Model Management" begin
+        hier_shape = HierarchicalShapeModel(base_shape)
+        
+        # Create a simple roughness model (2x2 grid)
+        roughness_nodes = [
+            SA[0.0, 0.0, 0.0],
+            SA[1.0, 0.0, 0.0],
+            SA[0.0, 1.0, 0.0],
+            SA[1.0, 1.0, 0.0]
+        ]
+        roughness_faces = [
+            SA[1, 2, 3],
+            SA[2, 4, 3]
+        ]
+        roughness_model = ShapeModel(roughness_nodes, roughness_faces)
+        
+        @testset "add_roughness_models! - single face" begin
+            # Add to single face
+            add_roughness_models!(hier_shape, roughness_model, 1, scale=0.1)
+            
+            @test has_roughness_model(hier_shape, 1) == true
+            @test has_roughness_model(hier_shape, 2) == false
+            @test get_roughness_model(hier_shape, 1) === roughness_model
+            @test get_roughness_model(hier_shape, 2) === nothing
+            @test get_roughness_model_scale(hier_shape, 1) == 0.1
+            @test get_roughness_model_scale(hier_shape, 2) == 1.0  # Default scale for faces without roughness
+            @test get_roughness_model_transform(hier_shape, 1) != AsteroidShapeModels.IDENTITY_AFFINE_MAP
+            @test get_roughness_model_transform(hier_shape, 2) == AsteroidShapeModels.IDENTITY_AFFINE_MAP  # Default transform
+        end
+        
+        @testset "add_roughness_models! - multiple faces" begin
+            # Add to multiple faces
+            add_roughness_models!(hier_shape, roughness_model, 2, scale=0.05)
+            add_roughness_models!(hier_shape, roughness_model, 3, scale=0.05)
+            
+            @test has_roughness_model(hier_shape, 2) == true
+            @test has_roughness_model(hier_shape, 3) == true
+            @test get_roughness_model_scale(hier_shape, 2) == 0.05
+            @test get_roughness_model_scale(hier_shape, 3) == 0.05
+        end
+        
+        @testset "clear_roughness_models!" begin
+            # Clear specific face
+            clear_roughness_models!(hier_shape, 1)
+            @test has_roughness_model(hier_shape, 1) == false
+            @test has_roughness_model(hier_shape, 2) == true
+            
+            # Clear all faces
+            clear_roughness_models!(hier_shape)
+            @test all(!has_roughness_model(hier_shape, i) for i in 1:4)
+        end
+        
+        @testset "add_roughness_models! - error handling" begin
+            # Test invalid face indices
+            @test_throws BoundsError add_roughness_models!(hier_shape, roughness_model, 0)
+            @test_throws BoundsError add_roughness_models!(hier_shape, roughness_model, 5)
+            @test_throws BoundsError add_roughness_models!(hier_shape, roughness_model, -1)
+            
+            # Test invalid scale
+            @test_throws ArgumentError add_roughness_models!(hier_shape, roughness_model, 1, scale=-0.1)
+            @test_throws ArgumentError add_roughness_models!(hier_shape, roughness_model, 1, scale=0.0)
+        end
+    end
+    
+    @testset "Coordinate Transformations" begin
+        hier_shape = HierarchicalShapeModel(base_shape)
+        
+        # Create roughness model and add to face 1
+        roughness_model = ShapeModel(
+            [SA[0.0, 0.0, 0.0], SA[1.0, 0.0, 0.0], SA[0.0, 1.0, 0.0], SA[1.0, 1.0, 0.0]],
+            [SA[1, 2, 3], SA[2, 4, 3]],
+        )
+        add_roughness_models!(hier_shape, roughness_model, 1, scale=0.1)
+        
+        @testset "Point transformations" begin
+            # Test point at face center
+            face_center_global = hier_shape.global_shape.face_centers[1]
+            local_point = transform_point_global_to_local(hier_shape, 1, face_center_global)
+            
+            # Face center should map to (0.5, 0.5, 0.0) in local coordinates
+            @test local_point[1] ≈ 0.5 atol=1e-10
+            @test local_point[2] ≈ 0.5 atol=1e-10
+            @test local_point[3] ≈ 0.0 atol=1e-10
+            
+            # Test round-trip transformation
+            global_point_back = transform_point_local_to_global(hier_shape, 1, local_point)
+            @test global_point_back ≈ face_center_global
+            
+            # Test arbitrary point
+            test_point = SVector(0.2, 0.3, 0.4)
+            local_test = transform_point_global_to_local(hier_shape, 1, test_point)
+            global_test = transform_point_local_to_global(hier_shape, 1, local_test)
+            @test global_test ≈ test_point
+        end
+        
+        @testset "Geometric vector transformations" begin
+            # Test with face normal
+            face_normal_global = hier_shape.global_shape.face_normals[1]
+            local_normal = transform_geometric_vector_global_to_local(hier_shape, 1, face_normal_global)
+            
+            # Face normal should point in +z direction in local coordinates
+            @test abs(local_normal[1]) < 1e-10
+            @test abs(local_normal[2]) < 1e-10
+            @test local_normal[3] ≈ 1.0
+            
+            # Test round-trip
+            global_normal_back = transform_geometric_vector_local_to_global(hier_shape, 1, local_normal)
+            @test global_normal_back ≈ face_normal_global
+            
+            # Test that length is preserved
+            test_vec = normalize(SVector(1.0, 2.0, 3.0))
+            local_vec = transform_geometric_vector_global_to_local(hier_shape, 1, test_vec)
+            @test norm(local_vec) ≈ norm(test_vec)
+        end
+        
+        @testset "Physical vector transformations" begin
+            # Physical vectors should scale with the roughness scale
+            test_phys_vec = SVector(1.0, 0.0, 0.0)
+            local_phys = transform_physical_vector_global_to_local(hier_shape, 1, test_phys_vec)
+            
+            # Should be scaled by 1/scale = 1/0.1 = 10
+            @test norm(local_phys) ≈ 10.0 * norm(test_phys_vec)
+            
+            # Test round-trip
+            global_phys_back = transform_physical_vector_local_to_global(hier_shape, 1, local_phys)
+            @test global_phys_back ≈ test_phys_vec
+        end
+        
+        @testset "Transformations without roughness model" begin
+            # Test face without roughness model
+            @test_throws ArgumentError transform_point_global_to_local(hier_shape, 4, SVector(0.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_geometric_vector_global_to_local(hier_shape, 4, SVector(1.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_physical_vector_global_to_local(hier_shape, 4, SVector(1.0, 0.0, 0.0))
+        end
+    end
+    
+    @testset "Local Coordinate System" begin
+        # Use helper function to create cube for testing different face orientations
+        cube_nodes, cube_faces = create_unit_cube()
+        cube_shape = ShapeModel(cube_nodes, cube_faces)
+        hier_cube = HierarchicalShapeModel(cube_shape)
+        
+        @testset "Coordinate system properties" begin
+            for face_idx in 1:size(cube_faces, 2)
+                origin, e_x, e_y, e_z = AsteroidShapeModels.compute_local_coordinate_system(hier_cube, face_idx)
+                
+                # Origin should be at face center
+                @test origin ≈ cube_shape.face_centers[face_idx]
+                
+                # Coordinate system should be orthonormal
+                @test norm(e_x) ≈ 1.0
+                @test norm(e_y) ≈ 1.0
+                @test norm(e_z) ≈ 1.0
+                @test abs(dot(e_x, e_y)) < 1e-10
+                @test abs(dot(e_x, e_z)) < 1e-10
+                @test abs(dot(e_y, e_z)) < 1e-10
+                
+                # e_z should align with face normal
+                @test e_z ≈ cube_shape.face_normals[face_idx]
+                
+                # Right-handed system
+                @test cross(e_x, e_y) ≈ e_z
+            end
+        end
+        
+        @testset "North alignment for horizontal faces" begin
+            # Find faces that are roughly horizontal (normal pointing up or down)
+            for face_idx in 1:size(cube_faces, 2)
+                normal = cube_shape.face_normals[face_idx]
+                if abs(normal[3]) > 0.9  # Nearly horizontal
+                    origin, e_x, e_y, e_z = AsteroidShapeModels.compute_local_coordinate_system(hier_cube, face_idx)
+                    
+                    # e_x should point north (positive y direction in global frame)
+                    @test e_x[2] > 0.9
+                    @test abs(e_x[1]) < 0.1
+                    @test abs(e_x[3]) < 0.1
+                end
+            end
+        end
+    end
+    
+    @testset "compute_face_roughness_transform" begin
+        hier_shape = HierarchicalShapeModel(base_shape)
+        
+        # Test transform computation
+        transform = AsteroidShapeModels.compute_face_roughness_transform(hier_shape, 1, scale=0.1)
+        
+        @test transform isa AsteroidShapeModels.AFFINE_MAP_TYPE
+        
+        # Test that face center maps to (0.5, 0.5, 0.0)
+        face_center_global = hier_shape.global_shape.face_centers[1]
+        local_center = transform(face_center_global)
+        @test local_center[1] ≈ 0.5 atol=1e-10
+        @test local_center[2] ≈ 0.5 atol=1e-10
+        @test local_center[3] ≈ 0.0 atol=1e-10
+        
+        # Test with different scale
+        transform_large = AsteroidShapeModels.compute_face_roughness_transform(hier_shape, 1, scale=1.0)
+        transform_small = AsteroidShapeModels.compute_face_roughness_transform(hier_shape, 1, scale=0.01)
+        
+        # Same global point should map to same local UV coordinates
+        test_point = face_center_global + SVector(0.01, 0.01, 0.01)
+        local_large = transform_large(test_point)
+        local_small = transform_small(test_point)
+        
+        # UV coordinates should be different due to scale
+        @test !isapprox(local_large, local_small)
+    end
+    
+    @testset "Integration with ShapeModel interface" begin
+        hier_shape = HierarchicalShapeModel(base_shape)
+        
+        # Test that HierarchicalShapeModel works with existing functions
+        @test equivalent_radius(hier_shape) ≈ equivalent_radius(base_shape)
+        @test maximum_radius(hier_shape) ≈ maximum_radius(base_shape)
+        @test minimum_radius(hier_shape) ≈ minimum_radius(base_shape)
+        @test polyhedron_volume(hier_shape) ≈ polyhedron_volume(base_shape)
+        
+        # Test ray intersection
+        ray = Ray(SVector(2.0, 0.0, 0.0), SVector(-1.0, 0.0, 0.0))
+        result_hier = intersect_ray_shape(ray, hier_shape)
+        result_base = intersect_ray_shape(ray, base_shape)
+        @test result_hier.hit == result_base.hit
+        if result_hier.hit
+            @test result_hier.distance ≈ result_base.distance
+            @test result_hier.point ≈ result_base.point
+            @test result_hier.face_idx == result_base.face_idx
+        end
+    end
+end

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -166,16 +166,15 @@ Tests cover:
         end
         
         @testset "Physical vector transformations" begin
-            # Physical vectors should scale with the roughness scale
-            test_phys_vec = SVector(1.0, 0.0, 0.0)
-            local_phys = transform_physical_vector_global_to_local(hier_shape, 1, test_phys_vec)
+            # Test with arbitrary physical vector
+            v_global = SVector(1.0, 2.0, 3.0)
+            v_local = transform_physical_vector_global_to_local(hier_shape, 1, v_global)
             
-            # Should be scaled by 1/scale = 1/0.1 = 10
-            @test norm(local_phys) ≈ 10.0 * norm(test_phys_vec)
+            # Physical vectors should not scaled with the roughness scale
+            @test norm(v_local) ≈ norm(v_global)
             
             # Test round-trip
-            global_phys_back = transform_physical_vector_local_to_global(hier_shape, 1, local_phys)
-            @test global_phys_back ≈ test_phys_vec
+            @test transform_physical_vector_local_to_global(hier_shape, 1, v_local) ≈ v_global
         end
         
         @testset "Transformations without roughness model" begin

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -15,14 +15,11 @@ Tests cover:
     ║                   Test: HierarchicalShapeModel                    ║
     ╚═══════════════════════════════════════════════════════════════════╝
     """
-    println(msg)
-    
-    # Use helper function to create test shapes
-    tetra_nodes, tetra_faces = create_regular_tetrahedron()
-    base_shape = ShapeModel(tetra_nodes, tetra_faces)
+    println(msg)    
     
     @testset "Construction and Basic Properties" begin
-        # Test basic construction
+        tetra_nodes, tetra_faces = create_regular_tetrahedron()
+        base_shape = ShapeModel(tetra_nodes, tetra_faces)
         hier_shape = HierarchicalShapeModel(base_shape)
         
         @test hier_shape isa HierarchicalShapeModel
@@ -45,6 +42,8 @@ Tests cover:
     end
     
     @testset "Roughness Model Management" begin
+        tetra_nodes, tetra_faces = create_regular_tetrahedron()
+        base_shape = ShapeModel(tetra_nodes, tetra_faces)
         hier_shape = HierarchicalShapeModel(base_shape)
         
         # Create a simple roughness model (2x2 grid)
@@ -109,6 +108,8 @@ Tests cover:
     end
     
     @testset "Coordinate Transformations" begin
+        tetra_nodes, tetra_faces = create_regular_tetrahedron()
+        base_shape = ShapeModel(tetra_nodes, tetra_faces)
         hier_shape = HierarchicalShapeModel(base_shape)
         
         # Create roughness model and add to face 1
@@ -169,7 +170,7 @@ Tests cover:
             # Test with arbitrary physical vector
             v_global = SVector(1.0, 2.0, 3.0)
             v_local = transform_physical_vector_global_to_local(hier_shape, 1, v_global)
-            
+
             # Physical vectors should not scaled with the roughness scale
             @test norm(v_local) ≈ norm(v_global)
             
@@ -191,15 +192,15 @@ Tests cover:
     @testset "Local Coordinate System" begin
         # Use helper function to create cube for testing different face orientations
         cube_nodes, cube_faces = create_unit_cube()
-        cube_shape = ShapeModel(cube_nodes, cube_faces)
-        hier_cube = HierarchicalShapeModel(cube_shape)
-        
+        base_shape = ShapeModel(cube_nodes, cube_faces)
+        hier_shape = HierarchicalShapeModel(base_shape)
+
         @testset "Coordinate system properties" begin
             for face_idx in 1:size(cube_faces, 2)
-                origin, e_x, e_y, e_z = AsteroidShapeModels.compute_local_coordinate_system(hier_cube, face_idx)
-                
+                origin, e_x, e_y, e_z = AsteroidShapeModels.compute_local_coordinate_system(hier_shape, face_idx)
+
                 # Origin should be at face center
-                @test origin ≈ cube_shape.face_centers[face_idx]
+                @test origin ≈ base_shape.face_centers[face_idx]
                 
                 # Coordinate system should be orthonormal
                 @test norm(e_x) ≈ 1.0
@@ -210,8 +211,8 @@ Tests cover:
                 @test abs(dot(e_y, e_z)) < 1e-10
                 
                 # e_z should align with face normal
-                @test e_z ≈ cube_shape.face_normals[face_idx]
-                
+                @test e_z ≈ base_shape.face_normals[face_idx]
+
                 # Right-handed system
                 @test cross(e_x, e_y) ≈ e_z
             end
@@ -234,6 +235,8 @@ Tests cover:
     end
     
     @testset "compute_face_roughness_transform" begin
+        tetra_nodes, tetra_faces = create_regular_tetrahedron()
+        base_shape = ShapeModel(tetra_nodes, tetra_faces)
         hier_shape = HierarchicalShapeModel(base_shape)
         
         # Test transform computation
@@ -263,7 +266,8 @@ Tests cover:
     
     @testset "Integration with ShapeModel interface" begin
         # Create base shape with BVH for ray intersection tests
-        base_shape_with_bvh = ShapeModel(tetra_nodes, tetra_faces, with_bvh=true)
+        tetra_nodes, tetra_faces = create_regular_tetrahedron()
+        base_shape_with_bvh = ShapeModel(tetra_nodes, tetra_faces; with_bvh=true)
         hier_shape = HierarchicalShapeModel(base_shape_with_bvh)
         
         # Test that HierarchicalShapeModel works with existing functions

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -147,22 +147,22 @@ Tests cover:
         
         @testset "Geometric vector transformations" begin
             # Test with face normal
+            scale = get_roughness_model_scale(hier_shape, 1)
             face_normal_global = hier_shape.global_shape.face_normals[1]
-            local_normal = transform_geometric_vector_global_to_local(hier_shape, 1, face_normal_global)
+            face_normal_local = transform_geometric_vector_global_to_local(hier_shape, 1, face_normal_global)
             
             # Face normal should point in +z direction in local coordinates
-            @test abs(local_normal[1]) < 1e-10
-            @test abs(local_normal[2]) < 1e-10
-            @test local_normal[3] ≈ 1.0
+            @test abs(face_normal_local[1]) < 1e-10
+            @test abs(face_normal_local[2]) < 1e-10
+            @test face_normal_local[3] ≈ 1.0 / scale
             
             # Test round-trip
-            global_normal_back = transform_geometric_vector_local_to_global(hier_shape, 1, local_normal)
-            @test global_normal_back ≈ face_normal_global
+            @test transform_geometric_vector_local_to_global(hier_shape, 1, face_normal_local) ≈ face_normal_global
             
-            # Test that length is preserved
-            test_vec = normalize(SVector(1.0, 2.0, 3.0))
-            local_vec = transform_geometric_vector_global_to_local(hier_shape, 1, test_vec)
-            @test norm(local_vec) ≈ norm(test_vec)
+            # Test if geometric vector length is scaled
+            v_global = normalize(SVector(1.0, 2.0, 3.0))
+            v_local = transform_geometric_vector_global_to_local(hier_shape, 1, v_global)
+            @test norm(v_local) ≈ norm(v_global) / scale
         end
         
         @testset "Physical vector transformations" begin


### PR DESCRIPTION
## Summary

This PR introduces `HierarchicalShapeModel`, a new shape model type that supports multi-scale surface representation for asteroids. This allows detailed surface features (craters, boulders, roughness) to be added to base shape models while maintaining computational efficiency.

## Features

- **New type**: `HierarchicalShapeModel <: AbstractShapeModel`
- **Surface roughness management**: Add/retrieve roughness models for individual faces
- **Coordinate transformations**: Full support for transforming between global and local coordinate systems
- **Physical vector support**: Separate transformation functions for physical quantities (forces, torques)

## Implementation Details

### Type Hierarchy
- Added `AbstractShapeModel` as base type
- `ShapeModel` and `HierarchicalShapeModel` inherit from it

### Coordinate System Convention
Local coordinate systems follow geographic conventions:
- Origin: Face center (0.5, 0.5) in UV coordinates
- X-axis: East
- Y-axis: North  
- Z-axis: Up (face normal)

### API Functions
- `add_roughness_model!` - Attach roughness model to a face
- `get_roughness_model` - Retrieve roughness model
- `get_roughness_model_scale` - Get scale factor (returns 1.0 if no roughness)
- `has_roughness` - Check if face has roughness
- `transform_point_*` - Point transformations
- `transform_vector_*` - Geometric vector transformations (with scaling)
- `transform_physical_vector_*` - Physical vector transformations (no scaling)

## TODO

- [ ] Add comprehensive tests for `HierarchicalShapeModel`
- [ ] Add tests for coordinate transformation functions
- [ ] Add tests for physical vector transformations
- [ ] Add usage examples in documentation
- [ ] Add benchmark comparisons
- [ ] Document all exported functions and types

## Related Issues

Part of v0.5.0 roadmap for hierarchical surface roughness models.

🤖 Generated with [Claude Code](https://claude.ai/code)