### PR TITLE
fix(test): update HERA SPICE kernel download URL to public ESAC FTP server

### DIFF
--- a/test/test_eclipse_shadowing.jl
+++ b/test/test_eclipse_shadowing.jl
@@ -25,18 +25,18 @@ they produce identical results.
     
     ## --- Download SPICE kernels ---
     for path_kernel in paths_kernel
-        url_kernel = "https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/$(path_kernel)?at=refs%2Ftags%2Fv161_20230929_001"
+        url_kernel = "https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/$(path_kernel)"
         filepath = joinpath("kernel", path_kernel)
         mkpath(dirname(filepath))
         isfile(filepath) || Downloads.download(url_kernel, filepath)
     end
-    
+
     ## --- Download shape models ---
     for path_shape in paths_shape
-        url_kernel = "https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/dsk/$(path_shape)?at=refs%2Ftags%2Fv161_20230929_001"
+        url_shape = "https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/dsk/$(path_shape)"
         filepath = joinpath("shape", path_shape)
         mkpath(dirname(filepath))
-        isfile(filepath) || Downloads.download(url_kernel, filepath)
+        isfile(filepath) || Downloads.download(url_shape, filepath)
     end
     
     ## --- Load the SPICE kernels ---


### PR DESCRIPTION
## Summary

- Replace ESA BitBucket URLs (`s2e2.cosmos.esa.int`) with public ESAC FTP server URLs (`spiftp.esac.esa.int`) for downloading HERA SPICE kernels and shape models in CI tests
- The BitBucket server now requires authentication, causing downloads to return HTML instead of kernel files, which breaks the Eclipse Shadowing tests in CI

## Changes

- `test/test_eclipse_shadowing.jl`: Update kernel and shape model download URLs
  - Kernel URL: `https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/<path>`
  - Shape model URL: `https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/dsk/<file>`
  - Also fix variable name: `url_kernel` → `url_shape` for shape model downloads

## Notes on Version Pinning

The old URL pinned a specific BitBucket tag (`v161_20230929_001`), but the new URL does not have an explicit version tag. However, since kernel filenames themselves encode version information (e.g., `hera_v10.tf`, `naif0012.tls`, `hera_didymos_v06.tpc`), the downloads remain effectively version-pinned. ESA's SPICE conventions keep old files when new versions are added under new names.

## Test plan

- [x] CI Eclipse Shadowing tests pass with new URLs
- [x] Kernel and shape model files are downloaded correctly in CI environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)