### PR TITLE
test: replace BenchmarkTools with correctness tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ MeshIO = "7269a6da-0436-5bbc-96c2-40638cbb6118"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-BenchmarkTools = "1.6.0"
 CoordinateTransformations = "0.6"
 FileIO = "1"
 GeometryBasics = "0.5"
@@ -24,7 +23,6 @@ StaticArrays = "1"
 julia = "1.10"
 
 [extras]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -34,4 +32,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SPICE", "Downloads", "Random", "BenchmarkTools", "Statistics", "Rotations"]
+test = ["Test", "SPICE", "Downloads", "Random", "Statistics", "Rotations"]

--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.6"
+julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "8048f3e80c34f28b0583fc2a2eac5bf392cd8796"
+project_hash = "e88b3a18901c50b0ff18bee358425437ed566e33"
 
 [[deps.AbstractTrees]]
 git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
@@ -51,10 +51,10 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.11.0"
 
 [[deps.AsteroidShapeModels]]
-deps = ["FileIO", "GeometryBasics", "ImplicitBVH", "LinearAlgebra", "MeshIO", "StaticArrays"]
+deps = ["CoordinateTransformations", "FileIO", "GeometryBasics", "ImplicitBVH", "LinearAlgebra", "MeshIO", "StaticArrays"]
 path = ".."
 uuid = "a7943d8e-5d65-4248-ae23-0082f5115a05"
-version = "0.4.1"
+version = "0.4.2"
 
 [[deps.Atomix]]
 deps = ["UnsafeAtomics"]
@@ -89,12 +89,10 @@ deps = ["FixedPointNumbers", "Random"]
 git-tree-sha1 = "67e11ee83a43eb71ddc950302c53bf33f0690dfe"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 version = "0.12.1"
+weakdeps = ["StyledStrings"]
 
     [deps.ColorTypes.extensions]
     StyledStringsExt = "StyledStrings"
-
-    [deps.ColorTypes.weakdeps]
-    StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
@@ -109,7 +107,13 @@ weakdeps = ["Dates", "LinearAlgebra"]
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.1.1+0"
+version = "1.3.0+1"
+
+[[deps.CoordinateTransformations]]
+deps = ["LinearAlgebra", "StaticArrays"]
+git-tree-sha1 = "a692f5e257d332de1e554e4566a4e5a8a72de2b2"
+uuid = "150eb455-5306-5404-9cee-2592286d6298"
+version = "0.6.4"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -124,7 +128,7 @@ version = "0.9.5"
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.EarCut_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -207,6 +211,11 @@ git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.4"
 
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
 [[deps.KernelAbstractions]]
 deps = ["Adapt", "Atomix", "InteractiveUtils", "MacroTools", "PrecompileTools", "Requires", "StaticArrays", "UUIDs"]
 git-tree-sha1 = "38a03910123867c11af988e8718d12c98bf6a234"
@@ -235,24 +244,24 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.6.0+0"
+version = "8.15.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.7.2+0"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -261,7 +270,7 @@ version = "1.11.0"
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-version = "1.11.0"
+version = "1.12.0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -273,14 +282,9 @@ uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 version = "0.5.16"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
-
-[[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.6+0"
 
 [[deps.MeshIO]]
 deps = ["ColorTypes", "FileIO", "GeometryBasics", "Printf"]
@@ -294,16 +298,21 @@ version = "1.11.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.12.12"
+version = "2025.11.4"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.27+1"
+version = "0.3.29+0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
@@ -314,7 +323,7 @@ version = "2.8.3"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.11.0"
+version = "1.12.1"
 
     [deps.Pkg.extensions]
     REPLExt = "REPL"
@@ -346,6 +355,7 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 version = "1.11.0"
 
 [[deps.Profile]]
+deps = ["StyledStrings"]
 uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 version = "1.11.0"
 
@@ -401,6 +411,10 @@ version = "1.11.1"
     [deps.Statistics.weakdeps]
     SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
@@ -440,19 +454,19 @@ version = "0.3.0"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+1"
+version = "1.3.1+2"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.11.0+0"
+version = "5.15.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.59.0+0"
+version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.7.0+0"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -44,11 +44,17 @@ SUITE["visibility"] = BenchmarkGroup()
 let view_dir = SA[1.0, 0.0, 0.0]
     # Single face query
     SUITE["visibility"]["single_face"] = @benchmarkable isilluminated($SHAPE_VIS, $view_dir, 1; with_self_shadowing=true)
-    
+    SUITE["visibility"]["pseudo_convex_single_face"] = @benchmarkable isilluminated($SHAPE, $view_dir, 1; with_self_shadowing=false)
+
     # Batch queries
     SUITE["visibility"]["batch_100_faces"] = @benchmarkable begin
         for idx in 1:100
             isilluminated($SHAPE_VIS, $view_dir, idx; with_self_shadowing=true)
+        end
+    end
+    SUITE["visibility"]["pseudo_convex_batch_100"] = @benchmarkable begin
+        for idx in 1:100
+            isilluminated($SHAPE, $view_dir, idx; with_self_shadowing=false)
         end
     end
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,11 +14,10 @@ Test Categories:
 - Visibility analysis
 - Edge cases and error handling
 - Integration tests with SPICE
-- Performance benchmarks
+- Ryugu shape model correctness tests
 =#
 
 using AsteroidShapeModels
-using BenchmarkTools
 using Downloads
 using LinearAlgebra
 using Random

--- a/test/test_bvh_comprehensive.jl
+++ b/test/test_bvh_comprehensive.jl
@@ -83,12 +83,12 @@ All tests include correctness verification and performance benchmarks.
         
         test_ray = rays[1]
         
-        time_single = @belapsed intersect_ray_shape($test_ray, $shape)
+        time_single = @elapsed intersect_ray_shape(test_ray, shape)
         println("  Single ray: $(round(time_single * 1e6, digits=2)) μs")
-        
+
         # Batch rays
-        time_batch = @belapsed for ray in $rays
-            intersect_ray_shape(ray, $shape)
+        time_batch = @elapsed for ray in rays
+            intersect_ray_shape(ray, shape)
         end
         println("\n  Batch ($n_test_rays rays): $(round(time_batch * 1000, digits=2)) ms")
         println("  Average per ray: $(round(time_batch / n_test_rays * 1e6, digits=2)) μs")
@@ -160,18 +160,17 @@ All tests include correctness verification and performance benchmarks.
         # Sample faces for detailed timing
         sample_faces = collect(1:min(100, n_faces))
         
-        # Use setup parameter to avoid scope issues with @belapsed
-        time_per_face_with_vis = @belapsed begin
+        time_per_face_with_vis = @elapsed(begin
             for i in sample_faces
                 isilluminated(shape_with_vis, r☉, i; with_self_shadowing=true)
             end
-        end setup=(sample_faces=$sample_faces; shape_with_vis=$shape_with_vis; r☉=$r☉) / length(sample_faces)
-        
-        time_per_face_pseudo_convex = @belapsed begin
+        end) / length(sample_faces)
+
+        time_per_face_pseudo_convex = @elapsed(begin
             for i in sample_faces
                 isilluminated(shape_no_vis, r☉, i; with_self_shadowing=false)
             end
-        end setup=(sample_faces=$sample_faces; shape_no_vis=$shape_no_vis; r☉=$r☉) / length(sample_faces)
+        end) / length(sample_faces)
         
         println("  Average time per face:")
         println("    Full occlusion model : $(round(time_per_face_with_vis * 1e6, digits=2)) μs")

--- a/test/test_ryugu_shape_model.jl
+++ b/test/test_ryugu_shape_model.jl
@@ -1,13 +1,14 @@
 #= ====================================================================
-                 Ryugu Shape Model Performance Test
+                 Ryugu Shape Model Correctness Test
 ====================================================================
-This file benchmarks performance with a realistic asteroid shape model:
-- OBJ file loading with and without visibility calculation
-- Illumination checks for multiple faces
-- Ray-shape intersection performance
-- Memory usage and visibility graph statistics
+Correctness tests using a realistic asteroid shape model:
+- Shape loading and basic properties
+- Face geometry validity
+- Ray-shape intersection
+- Visibility graph statistics
+- Shape metrics
 - Uses the Ryugu test model (2976 nodes, 5932 faces)
-=# 
+=#
 
 @testset "Ryugu Shape Model Performance Test" begin
     msg = """\n
@@ -16,54 +17,58 @@ This file benchmarks performance with a realistic asteroid shape model:
     ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
     """
     println(msg)
-    
-    # Use the test shape model in the repository
+
     path_shape = joinpath("shape", "ryugu_test.obj")
-    
-    # Load shape models
+
     shape     = load_shape_obj(path_shape; with_face_visibility=false, with_bvh=true)
     shape_vis = load_shape_obj(path_shape; with_face_visibility=true,  with_bvh=true)
-    n_nodes = length(shape.nodes)
-    n_faces = length(shape.faces)
-    
-    println("\nShape model info:")
-    println("  - Nodes: $(n_nodes)")
-    println("  - Faces: $(n_faces)")
-        
-    # 1. Benchmark OBJ file loading (without visibility)
-    println("\n1. Benchmarking OBJ file loading (without visibility):")
-    bench_load = @benchmark load_shape_obj($path_shape; with_face_visibility=false)
-    display(bench_load)
-    println()
-        
-    # 2. Benchmark loading with visibility calculation
-    println("\n2. Benchmarking shape loading with visibility calculation:")
-    bench_load_vis = @benchmark load_shape_obj($path_shape; with_face_visibility=true)
-    display(bench_load_vis)
-    println()
-        
-    # 3. Benchmark illumination checks
-    println("\n3. Benchmarking illumination checks (100 faces):")
-    view_dir = SA[1.0, 0.0, 0.0]
-    bench_vis = @benchmark begin
-        for idx in 1:100
-            isilluminated($shape_vis, $view_dir, idx; with_self_shadowing=true)
-        end
+
+    @testset "Shape loading" begin
+        @test length(shape.nodes) == 2976
+        @test length(shape.faces) == 5932
+        @test length(shape.face_normals) == 5932
+        @test length(shape.face_areas)   == 5932
+        @test length(shape.face_centers) == 5932
     end
-    display(bench_vis)
-    println()
-        
-    # 4. Benchmark ray intersection
-    println("\n4. Benchmarking ray-shape intersection:")
-    ray = Ray([0.0, 0.0, 1000.0], [0.0, 0.0, -1.0])
-    bench_ray = @benchmark intersect_ray_shape($ray, $shape)
-    display(bench_ray)
-    println()
-        
-    # 5. Summary statistics
-    println("\n=== Summary ===")
-    total_visible_pairs = shape_vis.face_visibility_graph.nnz
-    println("Total visible facet pairs: $total_visible_pairs")
-    avg_visible_per_face = total_visible_pairs / n_faces
-    println("Average visible facets per face: $(round(avg_visible_per_face, digits=2))")
+
+    @testset "Face geometry" begin
+        # All face normals should be unit vectors
+        @test all(n -> norm(n) ≈ 1.0, shape.face_normals)
+
+        # All face areas should be positive
+        @test all(a -> a > 0.0, shape.face_areas)
+    end
+
+    @testset "Ray intersection" begin
+        # Ray from above should hit the shape
+        ray_hit  = Ray(SA[0.0, 0.0, 1000.0], SA[0.0, 0.0, -1.0])
+        result   = intersect_ray_shape(ray_hit, shape)
+        @test result.hit == true
+        @test result.distance > 0.0
+
+        # Ray pointing away should miss
+        ray_miss = Ray(SA[0.0, 0.0, 1000.0], SA[0.0, 0.0, 1.0])
+        result2  = intersect_ray_shape(ray_miss, shape)
+        @test result2.hit == false
+    end
+
+    @testset "Visibility graph" begin
+        @test shape_vis.face_visibility_graph.nnz > 0
+        avg_visible = shape_vis.face_visibility_graph.nnz / length(shape_vis.faces)
+        @test avg_visible > 0.0
+    end
+
+    @testset "Shape metrics" begin
+        @test polyhedron_volume(shape) > 0.0
+        @test equivalent_radius(shape) > 0.0
+        @test maximum_radius(shape)    ≥ minimum_radius(shape)
+    end
+
+    @testset "Illumination" begin
+        view_dir = SA[1.0, 0.0, 0.0]
+        # At least some faces should be illuminated
+        n_illuminated = count(i -> isilluminated(shape_vis, view_dir, i; with_self_shadowing=true),
+                              eachindex(shape_vis.faces))
+        @test 0 < n_illuminated < length(shape_vis.faces)
+    end
 end


### PR DESCRIPTION
## Summary

- Fixes `InexactError: Int32` overflow in `BenchmarkTools.tune!()` on 32-bit (x86) systems, which caused CI failures on `Julia 1 - ubuntu-latest - x86`
- Separates performance benchmarks from the test suite (tests verify correctness, `benchmark/` handles performance measurement)

## Changes

### Test suite
- `test/test_ryugu_shape_model.jl`: Replace `@benchmark` calls with `@test` correctness assertions (shape loading dimensions, face geometry, ray intersection, visibility graph, shape metrics, illumination)
- `test/test_bvh_comprehensive.jl`: Replace `@belapsed` with Julia's built-in `@elapsed` (timing values are only used for display)
- `test/runtests.jl`: Remove `using BenchmarkTools`
- `Project.toml`: Remove `BenchmarkTools` from `[compat]`, `[extras]`, and `[targets]`

### Benchmarks
- `benchmark/benchmarks.jl`: Add pseudo-convex illumination benchmarks (`with_self_shadowing=false`) for comparison with the full occlusion model
- `benchmark/Manifest.toml`: Re-resolve for Julia 1.12 (adds `CoordinateTransformations` introduced in v0.4.2)

## Root cause

`BenchmarkTools.tune!()` internally calls `ceil(Int32, x)` to determine the number of benchmark evaluations. For fast functions on x86, the estimated count exceeds `Int32` maximum (~2.15×10⁹), causing `InexactError`. This is a known BenchmarkTools limitation on 32-bit systems.

## Test plan

- [x] All CI environments pass (including `Julia 1 - ubuntu-latest - x86`)
- [x] Benchmarks run correctly: `julia --project=benchmark benchmark/benchmarks.jl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)