### PR TITLE
feat(hierarchical): add public coordinate transformation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Hierarchical shape models for multi-scale surface representation** (PR TBD)
+- **Hierarchical shape models for multi-scale surface representation** (#55, #58)
   - New `HierarchicalShapeModel` type that supports adding surface roughness to a base shape model
   - Roughness model management functions:
     - `has_roughness_model` - Check if a face has associated roughness
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Only the new signature remains: `apply_eclipse_shadowing!(illuminated_faces, shape1, shape2, r☉₁, r₁₂, R₁₂)`
   - This change was planned in v0.4.1 and scheduled for v0.5.0
 
-- **Removed `use_elevation_optimization` parameter** (PR TBD)
+- **Removed `use_elevation_optimization` parameter** (#52)
   - The `use_elevation_optimization` parameter has been removed from all illumination APIs
   - Elevation-based optimization is now always enabled when `with_self_shadowing=true`
   - Affected functions: `isilluminated`, `update_illumination!`

--- a/docs/src/api/roughness.md
+++ b/docs/src/api/roughness.md
@@ -17,6 +17,17 @@ add_roughness_models!
 clear_roughness_models!
 ```
 
+### Coordinate Transformations
+
+```@docs
+transform_point_global_to_local
+transform_point_local_to_global
+transform_geometric_vector_global_to_local
+transform_geometric_vector_local_to_global
+transform_physical_vector_global_to_local
+transform_physical_vector_local_to_global
+```
+
 ## Crater Modeling
 
 ```@docs

--- a/src/AsteroidShapeModels.jl
+++ b/src/AsteroidShapeModels.jl
@@ -61,6 +61,9 @@ include("hierarchical_shape_model.jl")
 export HierarchicalShapeModel
 export has_roughness_model, get_roughness_model, get_roughness_model_scale, get_roughness_model_transform
 export clear_roughness_models!, add_roughness_models!
+export transform_point_global_to_local, transform_point_local_to_global
+export transform_geometric_vector_global_to_local, transform_geometric_vector_local_to_global
+export transform_physical_vector_global_to_local, transform_physical_vector_local_to_global
 
 include("face_visibility_graph.jl")
 export FaceVisibilityGraph, build_face_visibility_graph!, view_factor

--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -624,6 +624,314 @@ function compute_face_roughness_transform(hier_shape::HierarchicalShapeModel, fa
 
     # 6. Invert this to get passive global→local transformation
     passive_global_to_local = inv(active_local_to_global)
-    
+
     return passive_global_to_local
+end
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                  Geometric Point Transformations                  ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+"""
+    transform_point_global_to_local(
+        hier_shape ::HierarchicalShapeModel,
+        face_idx   ::Int,
+        p_global   ::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a point from global to local coordinates.
+
+# Arguments
+- `hier_shape::HierarchicalShapeModel` : The hierarchical shape model
+- `face_idx::Int`                      : Index of the face (1-based)
+- `p_global::StaticVector{3}`          : Point in global coordinates
+
+# Returns
+- `SVector{3, Float64}` : Point in local roughness model coordinates [0,1]×[0,1]×ℝ
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If `face_idx` is out of bounds
+
+# Notes
+The local coordinate system has its origin at the face center, with:
+- X-axis pointing east
+- Y-axis pointing north
+- Z-axis pointing up (along face normal)
+The UV coordinates [0,1]×[0,1] are centered at (0.5, 0.5).
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+if has_roughness_model(hier_shape, face_idx)
+    p_local = transform_point_global_to_local(hier_shape, face_idx, p_global)
+end
+```
+"""
+function transform_point_global_to_local(
+    hier_shape ::HierarchicalShapeModel,
+    face_idx   ::Int,
+    p_global   ::StaticVector{3}
+)::SVector{3, Float64}
+    !has_roughness_model(hier_shape, face_idx) &&
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform to local coordinates."))
+    transform = get_roughness_model_transform(hier_shape, face_idx)
+    return transform(p_global)
+end
+
+"""
+    transform_point_local_to_global(
+        hier_shape ::HierarchicalShapeModel,
+        face_idx   ::Int,
+        p_local    ::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a point from local to global coordinates.
+
+# Arguments
+- `hier_shape::HierarchicalShapeModel` : The hierarchical shape model
+- `face_idx::Int`                      : Index of the face (1-based)
+- `p_local::StaticVector{3}`           : Point in local roughness model coordinates [0,1]×[0,1]×ℝ
+
+# Returns
+- `SVector{3, Float64}` : Point in global coordinates
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
+
+# Notes
+Inverse transformation of `transform_point_global_to_local`.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+if has_roughness_model(hier_shape, face_idx)
+    p_global = transform_point_local_to_global(hier_shape, face_idx, p_local)
+end
+```
+"""
+function transform_point_local_to_global(
+    hier_shape ::HierarchicalShapeModel,
+    face_idx   ::Int,
+    p_local    ::StaticVector{3}
+)::SVector{3, Float64}
+    !has_roughness_model(hier_shape, face_idx) &&
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform from local coordinates."))
+    transform = get_roughness_model_transform(hier_shape, face_idx)
+    return inv(transform)(p_local)
+end
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                  Geometric Vector Transformations                 ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+"""
+    transform_geometric_vector_global_to_local(
+        hier_shape ::HierarchicalShapeModel,
+        face_idx   ::Int,
+        v_global   ::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a geometric vector (displacement, velocity) from global to local coordinates.
+Applies both rotation and scaling.
+
+# Arguments
+- `hier_shape::HierarchicalShapeModel` : The hierarchical shape model
+- `face_idx::Int`                      : Index of the face (1-based)
+- `v_global::StaticVector{3}`          : Geometric vector in global coordinates
+
+# Returns
+- `SVector{3, Float64}` : Vector in local roughness model coordinates (scaled)
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
+
+# Notes
+For physical vectors (forces, torques) that should preserve magnitude,
+use `transform_physical_vector_global_to_local` instead.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+if has_roughness_model(hier_shape, face_idx)
+    v_local = transform_geometric_vector_global_to_local(hier_shape, face_idx, v_global)
+end
+```
+"""
+function transform_geometric_vector_global_to_local(
+    hier_shape ::HierarchicalShapeModel,
+    face_idx   ::Int,
+    v_global   ::StaticVector{3}
+)::SVector{3, Float64}
+    !has_roughness_model(hier_shape, face_idx) &&
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform to local coordinates."))
+    transform = get_roughness_model_transform(hier_shape, face_idx)
+    return transform.linear * v_global
+end
+
+"""
+    transform_geometric_vector_local_to_global(
+        hier_shape ::HierarchicalShapeModel,
+        face_idx   ::Int,
+        v_local    ::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a geometric vector (displacement, velocity) from local to global coordinates.
+Applies both rotation and scaling.
+
+# Arguments
+- `hier_shape::HierarchicalShapeModel` : The hierarchical shape model
+- `face_idx::Int`                      : Index of the face (1-based)
+- `v_local::StaticVector{3}`           : Geometric vector in local roughness model coordinates
+
+# Returns
+- `SVector{3, Float64}` : Vector in global coordinates (scaled)
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
+
+# Notes
+For physical vectors (forces, torques) that should preserve magnitude,
+use `transform_physical_vector_local_to_global` instead.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+if has_roughness_model(hier_shape, face_idx)
+    v_global = transform_geometric_vector_local_to_global(hier_shape, face_idx, v_local)
+end
+```
+"""
+function transform_geometric_vector_local_to_global(
+    hier_shape ::HierarchicalShapeModel,
+    face_idx   ::Int,
+    v_local    ::StaticVector{3}
+)::SVector{3, Float64}
+    !has_roughness_model(hier_shape, face_idx) &&
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform from local coordinates."))
+    transform = get_roughness_model_transform(hier_shape, face_idx)
+    return inv(transform.linear) * v_local
+end
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                    Physical Vector Transformations                ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+"""
+    transform_physical_vector_global_to_local(
+        hier_shape ::HierarchicalShapeModel,
+        face_idx   ::Int,
+        v_global   ::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a physical vector (force, torque, angular velocity) from global to local
+coordinates. Physical vectors are only rotated, not scaled, preserving their magnitude.
+
+# Arguments
+- `hier_shape::HierarchicalShapeModel` : The hierarchical shape model
+- `face_idx::Int`                      : Index of the face
+- `v_global::StaticVector{3}`          : Physical vector in global coordinates
+
+# Returns
+- `SVector{3, Float64}` : Physical vector in local coordinate frame (not scaled)
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
+
+# Notes
+Use this for quantities where physical magnitude must be preserved (forces, torques,
+angular velocities, magnetic fields). For geometric vectors use
+`transform_geometric_vector_global_to_local` instead.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+if has_roughness_model(hier_shape, face_idx)
+    v_local = transform_physical_vector_global_to_local(hier_shape, face_idx, v_global)
+end
+```
+"""
+function transform_physical_vector_global_to_local(
+    hier_shape ::HierarchicalShapeModel,
+    face_idx   ::Int,
+    v_global   ::StaticVector{3}
+)::SVector{3, Float64}
+    !has_roughness_model(hier_shape, face_idx) &&
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform to local coordinates."))
+    transform = get_roughness_model_transform(hier_shape, face_idx)
+    # transform.linear = (1/scale) * R'; multiply by scale to recover pure rotation R'
+    scale = hier_shape.face_roughness_scales[face_idx]
+    rotation = transform.linear * scale
+    return rotation * v_global
+end
+
+"""
+    transform_physical_vector_local_to_global(
+        hier_shape ::HierarchicalShapeModel,
+        face_idx   ::Int,
+        v_local    ::StaticVector{3}
+    ) -> SVector{3, Float64}
+
+Transform a physical vector (force, torque, angular velocity) from local to global
+coordinates. Physical vectors are only rotated, not scaled, preserving their magnitude.
+
+# Arguments
+- `hier_shape::HierarchicalShapeModel` : The hierarchical shape model
+- `face_idx::Int`                      : Index of the face
+- `v_local::StaticVector{3}`           : Physical vector in local coordinates
+
+# Returns
+- `SVector{3, Float64}` : Physical vector in global coordinate frame (not scaled)
+
+# Throws
+- `ArgumentError` : If the specified face has no roughness model
+- `BoundsError`   : If face_idx is out of bounds
+
+# Notes
+Use this for quantities where physical magnitude must be preserved (forces, torques,
+angular velocities, magnetic fields). For geometric vectors use
+`transform_geometric_vector_local_to_global` instead.
+
+!!! warning "Requires roughness model"
+    This function requires the face to have an assigned roughness model.
+    Always check with `has_roughness_model(hier_shape, face_idx)` before calling.
+
+# Usage
+```julia
+if has_roughness_model(hier_shape, face_idx)
+    v_global = transform_physical_vector_local_to_global(hier_shape, face_idx, v_local)
+end
+```
+"""
+function transform_physical_vector_local_to_global(
+    hier_shape ::HierarchicalShapeModel,
+    face_idx   ::Int,
+    v_local    ::StaticVector{3}
+)::SVector{3, Float64}
+    !has_roughness_model(hier_shape, face_idx) &&
+        throw(ArgumentError("Face $face_idx has no roughness model. Cannot transform from local coordinates."))
+    transform = get_roughness_model_transform(hier_shape, face_idx)
+    # transform.linear = (1/scale) * R'; multiply by scale to recover pure rotation R'
+    scale = hier_shape.face_roughness_scales[face_idx]
+    rotation = transform.linear * scale
+    return rotation' * v_local
 end

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -106,6 +106,80 @@ Tests cover:
         end
     end
 
+    @testset "Coordinate Transformations" begin
+        tetra_nodes, tetra_faces = create_regular_tetrahedron()
+        base_shape = ShapeModel(tetra_nodes, tetra_faces)
+        hier_shape = HierarchicalShapeModel(base_shape)
+
+        roughness_model = ShapeModel(
+            [SA[0.0, 0.0, 0.0], SA[1.0, 0.0, 0.0], SA[0.0, 1.0, 0.0], SA[1.0, 1.0, 0.0]],
+            [SA[1, 2, 3], SA[2, 4, 3]],
+        )
+        add_roughness_models!(hier_shape, roughness_model, 1, scale=0.1)
+
+        @testset "Point transformations" begin
+            face_center_global = hier_shape.global_shape.face_centers[1]
+            face_center_local  = transform_point_global_to_local(hier_shape, 1, face_center_global)
+
+            # Face center maps to UV center (0.5, 0.5, 0.0)
+            @test face_center_local ≈ [0.5, 0.5, 0.0]
+
+            # Round-trip: face center
+            @test transform_point_local_to_global(hier_shape, 1, face_center_local) ≈ face_center_global
+
+            # Round-trip: arbitrary point
+            p_global = SVector(0.2, 0.3, 0.4)
+            p_local  = transform_point_global_to_local(hier_shape, 1, p_global)
+            @test transform_point_local_to_global(hier_shape, 1, p_local) ≈ p_global
+
+            # Point offset along face normal: z-component reflects elevation / scale
+            face_normal_global = hier_shape.global_shape.face_normals[1]
+            offset  = 0.1
+            p_global = face_center_global + offset * face_normal_global
+            p_local  = transform_point_global_to_local(hier_shape, 1, p_global)
+            scale    = get_roughness_model_scale(hier_shape, 1)
+            @test p_local ≈ [0.5, 0.5, offset / scale]
+        end
+
+        @testset "Geometric vector transformations" begin
+            scale              = get_roughness_model_scale(hier_shape, 1)
+            face_normal_global = hier_shape.global_shape.face_normals[1]
+            face_normal_local  = transform_geometric_vector_global_to_local(hier_shape, 1, face_normal_global)
+
+            # Face normal should point in +z in local coordinates (scaled by 1/scale)
+            @test abs(face_normal_local[1]) < 1e-10
+            @test abs(face_normal_local[2]) < 1e-10
+            @test face_normal_local[3] ≈ 1.0 / scale
+
+            # Round-trip
+            @test transform_geometric_vector_local_to_global(hier_shape, 1, face_normal_local) ≈ face_normal_global
+
+            # Length is scaled
+            v_global = normalize(SVector(1.0, 2.0, 3.0))
+            v_local  = transform_geometric_vector_global_to_local(hier_shape, 1, v_global)
+            @test norm(v_local) ≈ norm(v_global) / scale
+        end
+
+        @testset "Physical vector transformations" begin
+            # Magnitude is preserved (rotation only, no scaling)
+            v_global = SVector(1.0, 2.0, 3.0)
+            v_local  = transform_physical_vector_global_to_local(hier_shape, 1, v_global)
+            @test norm(v_local) ≈ norm(v_global)
+
+            # Round-trip
+            @test transform_physical_vector_local_to_global(hier_shape, 1, v_local) ≈ v_global
+        end
+
+        @testset "Transformations without roughness model" begin
+            @test_throws ArgumentError transform_point_global_to_local(hier_shape, 4, SVector(0.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_point_local_to_global(hier_shape, 4, SVector(0.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_geometric_vector_global_to_local(hier_shape, 4, SVector(1.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_geometric_vector_local_to_global(hier_shape, 4, SVector(1.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_physical_vector_global_to_local(hier_shape, 4, SVector(1.0, 0.0, 0.0))
+            @test_throws ArgumentError transform_physical_vector_local_to_global(hier_shape, 4, SVector(1.0, 0.0, 0.0))
+        end
+    end
+
     @testset "Local Coordinate System" begin
         # Use helper function to create cube for testing different face orientations
         cube_nodes, cube_faces = create_unit_cube()


### PR DESCRIPTION
## Summary

Adds the public coordinate transformation API for `HierarchicalShapeModel`, completing the implementation started in #55.

- `transform_point_global_to_local` / `transform_point_local_to_global`
- `transform_geometric_vector_global_to_local` / `transform_geometric_vector_local_to_global`
- `transform_physical_vector_global_to_local` / `transform_physical_vector_local_to_global`

## Background

The local coordinate system for each face has:
- Origin at face center
- X-axis pointing east, Y-axis pointing north, Z-axis along face normal
- Face center in global coordinates maps to UV coordinates (0.5, 0.5, 0.0)

## Distinction between geometric and physical vectors

| Type | Transform | Use case |
|------|-----------|----------|
| Geometric | Rotation + scaling | Displacements, velocities |
| Physical | Rotation only (magnitude preserved) | Forces, torques, angular velocities |

## Changes

- `src/hierarchical_shape_model.jl`: Add 6 transformation functions
- `src/AsteroidShapeModels.jl`: Export the new functions
- `test/test_hierarchical_shape_model.jl`: Add "Coordinate Transformations" testset (17 new tests)
- `docs/src/api/roughness.md`: Add API reference section
- `CHANGELOG.md`: Update PR numbers in [Unreleased] section

## Test plan

- [x] CI passes on all environments
- [x] Point round-trip (global→local→global) is exact
- [x] Face center maps to UV center (0.5, 0.5, 0.0)
- [x] Physical vector magnitude is preserved under transformation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
