### PR TITLE
feat(hierarchical): forward `apply_eclipse_shadowing!` to `global_shape`

### DIFF
--- a/src/hierarchical_shape_model.jl
+++ b/src/hierarchical_shape_model.jl
@@ -233,6 +233,17 @@ isilluminated(hier_shape::HierarchicalShapeModel, r☉::StaticVector{3}, face_id
 update_illumination!(illuminated_faces::AbstractVector{Bool}, hier_shape::HierarchicalShapeModel, r☉::StaticVector{3}; with_self_shadowing::Bool) =
     update_illumination!(illuminated_faces, hier_shape.global_shape, r☉; with_self_shadowing)
 
+#### From `eclipse_shadowing.jl` ####
+
+apply_eclipse_shadowing!(illuminated_faces::AbstractVector{Bool}, hier::HierarchicalShapeModel, shape2::ShapeModel, r☉₁::StaticVector{3}, r₁₂::StaticVector{3}, R₁₂::StaticMatrix{3,3}) =
+    apply_eclipse_shadowing!(illuminated_faces, hier.global_shape, shape2, r☉₁, r₁₂, R₁₂)
+
+apply_eclipse_shadowing!(illuminated_faces::AbstractVector{Bool}, shape1::ShapeModel, hier::HierarchicalShapeModel, r☉₁::StaticVector{3}, r₁₂::StaticVector{3}, R₁₂::StaticMatrix{3,3}) =
+    apply_eclipse_shadowing!(illuminated_faces, shape1, hier.global_shape, r☉₁, r₁₂, R₁₂)
+
+apply_eclipse_shadowing!(illuminated_faces::AbstractVector{Bool}, hier1::HierarchicalShapeModel, hier2::HierarchicalShapeModel, r☉₁::StaticVector{3}, r₁₂::StaticVector{3}, R₁₂::StaticMatrix{3,3}) =
+    apply_eclipse_shadowing!(illuminated_faces, hier1.global_shape, hier2.global_shape, r☉₁, r₁₂, R₁₂)
+
 #### From `face_visibility_graph.jl` ####
 
 # Face visibility graph

--- a/test/test_hierarchical_shape_model.jl
+++ b/test/test_hierarchical_shape_model.jl
@@ -281,4 +281,36 @@ Tests cover:
             @test result_hier.face_idx == result_base.face_idx
         end
     end
+
+    @testset "Eclipse shadowing with HierarchicalShapeModel" begin
+        tetra_nodes, tetra_faces = create_regular_tetrahedron()
+        shape1 = ShapeModel(tetra_nodes, tetra_faces; with_bvh=true)
+        shape2 = ShapeModel(tetra_nodes, tetra_faces; with_bvh=true)
+        hier1  = HierarchicalShapeModel(shape1)
+        hier2  = HierarchicalShapeModel(shape2)
+
+        # shape2 is placed along +x, sun is in the +x direction
+        r☉₁ = SVector(1.0, 0.0, 0.0)
+        r₁₂ = SVector(5.0, 0.0, 0.0)
+        R₁₂ = SMatrix{3,3,Float64}(I)
+
+        nfaces = length(tetra_faces)
+        illuminated_ref    = trues(nfaces)
+        illuminated_hier1  = trues(nfaces)
+        illuminated_hier2  = trues(nfaces)
+        illuminated_hier12 = trues(nfaces)
+
+        status_ref    = apply_eclipse_shadowing!(illuminated_ref,    shape1, shape2, r☉₁, r₁₂, R₁₂)
+        status_hier1  = apply_eclipse_shadowing!(illuminated_hier1,  hier1,  shape2, r☉₁, r₁₂, R₁₂)
+        status_hier2  = apply_eclipse_shadowing!(illuminated_hier2,  shape1, hier2,  r☉₁, r₁₂, R₁₂)
+        status_hier12 = apply_eclipse_shadowing!(illuminated_hier12, hier1,  hier2,  r☉₁, r₁₂, R₁₂)
+
+        # All combinations should produce identical results
+        @test status_hier1  == status_ref
+        @test status_hier2  == status_ref
+        @test status_hier12 == status_ref
+        @test illuminated_hier1  == illuminated_ref
+        @test illuminated_hier2  == illuminated_ref
+        @test illuminated_hier12 == illuminated_ref
+    end
 end


### PR DESCRIPTION
## Summary

`apply_eclipse_shadowing!` previously only accepted `ShapeModel` arguments, so passing a `HierarchicalShapeModel` would result in a method dispatch error.

This PR adds three forwarding methods to `hierarchical_shape_model.jl` that delegate to `global_shape`, consistent with the existing forwarding pattern for other functions:

- `(HierarchicalShapeModel, ShapeModel)` → `(global_shape, shape2)`
- `(ShapeModel, HierarchicalShapeModel)` → `(shape1, global_shape)`
- `(HierarchicalShapeModel, HierarchicalShapeModel)` → `(global_shape1, global_shape2)`

No changes to `eclipse_shadowing.jl` are required.

## Test plan

- [x] New `"Eclipse shadowing with HierarchicalShapeModel"` testset verifies all three combinations produce identical `EclipseStatus` and `illuminated_faces` results as the reference `(ShapeModel, ShapeModel)` call
- [x] Full test suite passes (641 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)