### PR TITLE
docs: update `CHANGELOG` for #60 and fix stale docstring in `eclipse_shadowing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Automatic north-aligned local coordinate system for each face
   - Support for custom affine transformations per face
   - Scale factor is encoded in the affine transform (no redundant storage); `get_roughness_model_scale` recovers it on demand via `1 / ‖column‖` (#59)
+  - `apply_eclipse_shadowing!` now accepts `HierarchicalShapeModel` for either or both shape arguments, delegating to `global_shape` (#60)
 
 ### Breaking Changes
 - **Removed deprecated `apply_eclipse_shadowing!` signature** (#51)

--- a/src/eclipse_shadowing.jl
+++ b/src/eclipse_shadowing.jl
@@ -50,11 +50,6 @@ This is the recommended API as of v0.4.1, with more intuitive parameter ordering
     As of v0.4.0, `shape2` must have BVH pre-built before calling this function.
     Use either `with_bvh=true` when loading or call `build_bvh!(shape2)` explicitly.
 
-!!! tip "New in v0.4.1"
-    This function signature directly accepts `r₁₂` (shape2's position in shape1's frame),
-    which is more intuitive when working with SPICE data. The older signature using `t₁₂`
-    is maintained for backward compatibility but will be removed in v0.5.0.
-
 !!! warning "OPTIMIZE"
     Current implementation calls `intersect_ray_shape` per face, causing ~200 allocations per call.
     For binary asteroid thermophysical simulations, this results in ~200 allocations × 2 bodies × 


### PR DESCRIPTION
## Summary

- Add PR #60 (`apply_eclipse_shadowing!` forwarding for `HierarchicalShapeModel`) to the `[Unreleased]` section of `CHANGELOG.md`
- Remove stale admonition in `apply_eclipse_shadowing!` docstring that claimed the old `t₁₂` signature "will be removed in v0.5.0" — it was already removed in #51

## Test plan

- [x] Documentation-only changes; no functional code modified
- [x] CI documentation build will confirm docstring renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)