### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.5.0] - 2026-05-22
 
 ### Added
 - **Hierarchical shape models for multi-scale surface representation** (#55, #58, #59)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AsteroidShapeModels"
 uuid = "a7943d8e-5d65-4248-ae23-0082f5115a05"
 authors = ["Masanori Kanamaru <kanamaru-masanori@hotmail.co.jp>"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"

--- a/docs/src/guides/migration.md
+++ b/docs/src/guides/migration.md
@@ -12,9 +12,9 @@ If you encounter issues during migration:
 
 ## Future Deprecations
 
-No planned deprecations at this time.
+No planned deprecations at this time for v0.5.x.
 
-## Migrating to v0.5.0 (Unreleased)
+## Migrating to v0.5.0
 
 ### New Features
 


### PR DESCRIPTION
## Summary

Release v0.5.0 of `AsteroidShapeModels.jl`.

## Changes in this release

### Added
- `HierarchicalShapeModel` for multi-scale surface representation (#55, #58, #59, #60)
  - Roughness model management: `add_roughness_models!`, `clear_roughness_models!`, `has_roughness_model`, `get_roughness_model`, `get_roughness_model_scale`, `get_roughness_model_transform`
  - Coordinate transformation API: `transform_point_*`, `transform_geometric_vector_*`, `transform_physical_vector_*`
  - `apply_eclipse_shadowing!` now accepts `HierarchicalShapeModel` for either or both shape arguments

### Breaking Changes
- Removed deprecated `apply_eclipse_shadowing!` signature using `t₁₂` parameter (#51)
- Removed `use_elevation_optimization` parameter from `isilluminated` and `update_illumination!` (#52)

See [Migration Guide](docs/src/guides/migration.md) for upgrade instructions.

## Checklist
- [x] `Project.toml` version bumped to `0.5.0`
- [x] `CHANGELOG.md` `[Unreleased]` → `[0.5.0] - 2026-05-22`
- [x] Migration guide updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)