### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.1] - 2026-06-08
+
+### Added
+- **`create_shape_crater` function for concave spherical crater modeling** (#64)
+  - New high-level wrapper combining `concave_spherical_segment` and `load_shape_grid`
+  - Keyword arguments: `xc`, `yc` (crater center), `Nx`, `Ny` (grid resolution), `scale`, `with_face_visibility`, `with_bvh`, `as_hierarchical`
+  - Returns `ShapeModel` or `HierarchicalShapeModel` depending on `as_hierarchical`
+
+---
+
 ## [0.5.0] - 2026-05-22
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AsteroidShapeModels"
 uuid = "a7943d8e-5d65-4248-ae23-0082f5115a05"
 authors = ["Masanori Kanamaru <kanamaru-masanori@hotmail.co.jp>"]
-version = "0.5.1-DEV"
+version = "0.5.1"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,13 +85,19 @@ Please check our [GitHub Issues](https://github.com/Astroshaper/AsteroidShapeMod
 
 ---
 
+## Version 0.5.1 - Crater Shape Generation (Released: 2026-06-08)
+
+### Added
+- **`create_shape_crater` function** (#64): High-level API to create a crater `ShapeModel` directly from geometry parameters, intended for use as roughness models in `HierarchicalShapeModel`
+
+---
+
 ## Version 0.5.x - Patch Releases
 
 ### Roughness Module Enhancements
 - [ ] Implement parallel sinusoidal trench generation
 - [ ] Implement Random Gaussian surface generation
 - [ ] Implement Fractal surface generation
-- [ ] Add comprehensive test coverage for roughness features
 
 ### API Improvements
 - [ ] Improve error messages and validation


### PR DESCRIPTION
## Summary

Release v0.5.1 — Crater Shape Generation.

- Update CHANGELOG for v0.5.1
- Add v0.5.1 section to ROADMAP
- Bump version to 0.5.1

## Changes in this release

### Added
- `create_shape_crater`: High-level API to create a crater `ShapeModel` directly from geometry parameters, intended for use as roughness models in `HierarchicalShapeModel` (#64)